### PR TITLE
Add simplified Carta Porte form

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,4 +167,17 @@ pm2 monit
 
 # Restart aplicación
 pm2 restart trucking-api
+
+## Flujo simplificado de Carta Porte
+
+Para depurar o probar el formulario sin las optimizaciones completas puedes activar un modo simplificado.
+
+1. Pasa el prop `simplified` al componente `CartaPorteForm`.
+2. O define la variable de entorno `VITE_SIMPLIFIED_CARTA_PORTE=true` antes de compilar.
+
+```tsx
+<CartaPorteForm simplified />
+```
+
+Este modo mantiene el estado de manera básica y evita las conversiones de datos estables, facilitando la inspección durante el desarrollo.
 ¡Listo para automatizar el transporte de carga con Interconecta Trucking! 🚛📋✨

--- a/src/components/carta-porte/CartaPorteForm.tsx
+++ b/src/components/carta-porte/CartaPorteForm.tsx
@@ -4,6 +4,7 @@ import { Card, CardContent } from '@/components/ui/card';
 import { GuardarPlantillaDialog } from './plantillas/GuardarPlantillaDialog';
 import { AIValidationAlerts } from '@/components/ai/AIValidationAlerts';
 import { useCartaPorteForm } from '@/hooks/useCartaPorteForm';
+import { useCartaPorteFormSimplified } from '@/hooks/useCartaPorteFormSimplified';
 import { useTabNavigation } from '@/hooks/useTabNavigation';
 import { useCartaPorteCache } from '@/hooks/carta-porte/useCartaPorteCache';
 import { useCartaPortePerformance } from '@/hooks/carta-porte/useCartaPortePerformance';
@@ -44,9 +45,10 @@ export interface CartaPorteData {
 
 interface CartaPorteFormProps {
   cartaPorteId?: string;
+  simplified?: boolean;
 }
 
-export function CartaPorteForm({ cartaPorteId }: CartaPorteFormProps) {
+export function CartaPorteForm({ cartaPorteId, simplified }: CartaPorteFormProps) {
   const [showGuardarPlantilla, setShowGuardarPlantilla] = useState(false);
   const [showAIAlerts, setShowAIAlerts] = useState(true);
   
@@ -72,7 +74,11 @@ export function CartaPorteForm({ cartaPorteId }: CartaPorteFormProps) {
     formDataToCartaPorteData,
     formAutotransporteToData,
     formFigurasToData,
-  } = useCartaPorteForm({ cartaPorteId });
+  } = (
+    simplified || import.meta.env.VITE_SIMPLIFIED_CARTA_PORTE === 'true'
+      ? useCartaPorteFormSimplified({ cartaPorteId })
+      : useCartaPorteForm({ cartaPorteId })
+  );
 
   // Usar hook optimizado para navegación de pestañas
   const { activeTab, handleTabChange } = useTabNavigation({

--- a/src/hooks/useCartaPorteFormSimplified.ts
+++ b/src/hooks/useCartaPorteFormSimplified.ts
@@ -1,0 +1,97 @@
+import { useState, useCallback } from 'react';
+import { supabase } from '@/integrations/supabase/client';
+import { CartaPorteData } from '@/components/carta-porte/CartaPorteForm';
+import { UseCartaPorteFormOptions } from '@/hooks/carta-porte/types/useCartaPorteFormTypes';
+
+const initialData: CartaPorteData = {
+  tipoCreacion: 'manual',
+  tipoCfdi: 'Traslado',
+  rfcEmisor: '',
+  nombreEmisor: '',
+  rfcReceptor: '',
+  nombreReceptor: '',
+  transporteInternacional: false,
+  registroIstmo: false,
+  cartaPorteVersion: '3.1',
+  ubicaciones: [],
+  mercancias: [],
+  autotransporte: {},
+  figuras: [],
+};
+
+export function useCartaPorteFormSimplified({ cartaPorteId }: UseCartaPorteFormOptions = {}) {
+  const [formData, setFormData] = useState<CartaPorteData>({ ...initialData, cartaPorteId });
+  const [currentCartaPorteId, setCurrentCartaPorteId] = useState<string | undefined>(cartaPorteId);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const updateFormData = useCallback((section: keyof CartaPorteData, data: any) => {
+    setFormData(prev => ({ ...prev, [section]: data }));
+  }, []);
+
+  const loadCartaPorte = useCallback(async (id: string) => {
+    setIsLoading(true);
+    try {
+      const { data, error } = await supabase
+        .from('cartas_porte')
+        .select('datos_formulario')
+        .eq('id', id)
+        .single();
+      if (error) throw error;
+      if (data?.datos_formulario) {
+        setFormData(data.datos_formulario as CartaPorteData);
+        setCurrentCartaPorteId(id);
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  const saveCartaPorte = useCallback(async () => {
+    if (!currentCartaPorteId) return;
+    setIsLoading(true);
+    try {
+      await supabase
+        .from('cartas_porte')
+        .update({ datos_formulario: formData })
+        .eq('id', currentCartaPorteId);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [formData, currentCartaPorteId]);
+
+  const createNewCartaPorte = useCallback((initial?: Partial<CartaPorteData>) => {
+    setFormData({ ...initialData, ...initial });
+    setCurrentCartaPorteId(undefined);
+  }, []);
+
+  const resetForm = useCallback(() => {
+    setFormData(initialData);
+    setCurrentCartaPorteId(undefined);
+  }, []);
+
+  return {
+    formData,
+    currentCartaPorteId,
+    isLoading,
+    updateFormData,
+    loadCartaPorte,
+    saveCartaPorte,
+    createNewCartaPorte,
+    resetForm,
+    stepValidations: {},
+    totalProgress: 0,
+    clearSavedData: () => {},
+    isCreating: false,
+    isUpdating: false,
+    aiValidation: null,
+    hasAIEnhancements: false,
+    validationMode: 'off',
+    overallScore: 0,
+    formDataToCartaPorteData: () => formData,
+    formAutotransporteToData: (data: any) => data || formData.autotransporte,
+    formFigurasToData: (data: any) => data || formData.figuras,
+    formDataExtendidoToCartaPorteData: (data: CartaPorteData) => data,
+    cartaPorteDataToFormDataExtendido: (data: CartaPorteData) => data,
+  };
+}
+


### PR DESCRIPTION
## Summary
- introduce `useCartaPorteFormSimplified` with minimal state
- toggle simplified mode in `CartaPorteForm` via prop or env flag
- document simplified flow in README

## Testing
- `npm run lint` *(fails: 423 errors, 36 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_684cfcb328c4832b8e2cc807b6446443