### PR TITLE
Fix Gemini function parameter mismatch

### DIFF
--- a/src/services/ai/GeminiAutocompleteService.ts
+++ b/src/services/ai/GeminiAutocompleteService.ts
@@ -59,7 +59,7 @@ export class GeminiAutocompleteService {
       
       const { data, error } = await supabase.functions.invoke('gemini-assistant', {
         body: {
-          action: 'autocomplete_address',
+          operation: 'autocomplete_address',
           input,
           context: {
             ...context,
@@ -93,7 +93,7 @@ export class GeminiAutocompleteService {
       
       const { data, error } = await supabase.functions.invoke('gemini-assistant', {
         body: {
-          action: 'autocomplete_mercancia',
+          operation: 'autocomplete_mercancia',
           input,
           context: {
             ...context,
@@ -127,7 +127,7 @@ export class GeminiAutocompleteService {
       
       const { data, error } = await supabase.functions.invoke('gemini-assistant', {
         body: {
-          action: 'autocomplete_vehiculo',
+          operation: 'autocomplete_vehiculo',
           input,
           context: {
             ...context,

--- a/src/services/ai/GeminiCoreService.ts
+++ b/src/services/ai/GeminiCoreService.ts
@@ -60,12 +60,12 @@ export class GeminiCoreService {
     return GeminiCoreService.instance;
   }
 
-  private getCacheKey(action: string, input: string, context?: any): string {
-    return `${action}-${input}-${JSON.stringify(context)}`;
+  private getCacheKey(operation: string, input: string, context?: any): string {
+    return `${operation}-${input}-${JSON.stringify(context)}`;
   }
 
-  private async callGeminiAPI(action: string, data: any, context?: AIContextData): Promise<any> {
-    const cacheKey = this.getCacheKey(action, JSON.stringify(data), context);
+  private async callGeminiAPI(operation: string, data: any, context?: AIContextData): Promise<any> {
+    const cacheKey = this.getCacheKey(operation, JSON.stringify(data), context);
     
     // Check cache first
     const cached = this.cache.get(cacheKey);
@@ -76,7 +76,7 @@ export class GeminiCoreService {
     try {
       const { data: result, error } = await supabase.functions.invoke('gemini-assistant', {
         body: {
-          action,
+          operation,
           data,
           context: {
             ...context,
@@ -90,10 +90,10 @@ export class GeminiCoreService {
 
       // Cache the result
       this.cache.set(cacheKey, { data: result, timestamp: Date.now() });
-      
+
       return result;
     } catch (error) {
-      console.error(`[GeminiCore] Error in ${action}:`, error);
+      console.error(`[GeminiCore] Error in ${operation}:`, error);
       throw error;
     }
   }

--- a/src/services/ai/GeminiValidationService.ts
+++ b/src/services/ai/GeminiValidationService.ts
@@ -38,7 +38,7 @@ export class GeminiValidationService {
       
       const { data, error } = await supabase.functions.invoke('gemini-assistant', {
         body: {
-          action: 'validate_direccion',
+          operation: 'validate_direccion',
           data: direccion,
           context: {
             pais: 'México',
@@ -71,7 +71,7 @@ export class GeminiValidationService {
       
       const { data, error } = await supabase.functions.invoke('gemini-assistant', {
         body: {
-          action: 'validate_mercancia_advanced',
+          operation: 'validate_mercancia_advanced',
           data: mercancia,
           context: {
             catalogo_sat: true,
@@ -105,7 +105,7 @@ export class GeminiValidationService {
       
       const { data, error } = await supabase.functions.invoke('gemini-assistant', {
         body: {
-          action: 'validate_coherencia_carta_porte',
+          operation: 'validate_coherencia_carta_porte',
           data: cartaPorteData,
           context: {
             validacion_cruzada: true,
@@ -132,7 +132,7 @@ export class GeminiValidationService {
     try {
       const { data: result, error } = await supabase.functions.invoke('gemini-assistant', {
         body: {
-          action: 'detect_anomalies',
+          operation: 'detect_anomalies',
           data,
           context: {
             tipo,

--- a/src/services/crm/RouteOptimizer.ts
+++ b/src/services/crm/RouteOptimizer.ts
@@ -74,7 +74,7 @@ export class RouteOptimizer {
       // Usar Gemini AI para optimización inteligente
       const { data, error } = await supabase.functions.invoke('gemini-assistant', {
         body: {
-          action: 'optimize_route',
+          operation: 'optimize_route',
           data: {
             puntos,
             criterios

--- a/src/services/documentProcessor.ts
+++ b/src/services/documentProcessor.ts
@@ -176,7 +176,7 @@ export class DocumentProcessor {
     try {
       const { data, error } = await supabase.functions.invoke('gemini-assistant', {
         body: {
-          action: 'parse_document',
+          operation: 'parse_document',
           data: {
             text: text,
             document_type: documentType

--- a/supabase/functions/gemini-assistant/index.ts
+++ b/supabase/functions/gemini-assistant/index.ts
@@ -11,8 +11,24 @@ serve(async (req) => {
   }
 
   try {
-    const { operation, data } = await req.json();
-    console.log('[GEMINI] Received operation:', operation);
+    const { operation, action, data } = await req.json();
+
+    let op = operation || action;
+
+    // Support legacy action field names
+    switch (op) {
+      case 'autocomplete_address':
+        op = 'autocomplete_direccion';
+        break;
+      case 'validate_mercancia_advanced':
+        op = 'validate_mercancia';
+        break;
+      case 'validate_direccion':
+        op = 'validate_section';
+        break;
+    }
+
+    console.log('[GEMINI] Received operation:', op);
 
     if (!geminiApiKey) {
       throw new Error('GEMINI_API_KEY not configured');
@@ -21,7 +37,7 @@ serve(async (req) => {
     let prompt = '';
     let responseFormat = 'json';
 
-    switch (operation) {
+    switch (op) {
       case 'autocomplete_direccion':
         prompt = `
         Completa esta dirección mexicana: "${data.input}"
@@ -65,10 +81,10 @@ serve(async (req) => {
         break;
 
       default:
-        throw new Error(`Operation ${operation} not supported`);
+        throw new Error(`Operation ${op} not supported`);
     }
 
-    console.log('[GEMINI] Calling Gemini API for operation:', operation);
+    console.log('[GEMINI] Calling Gemini API for operation:', op);
 
     // Call Gemini API
     const geminiResponse = await fetch(


### PR DESCRIPTION
## Summary
- accept both `operation` and legacy `action` parameters on Gemini edge function
- use `operation` in Gemini client services
- add alias handling for mismatched operation names

## Testing
- `npm run lint` *(fails: 424 errors, 36 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_684d09bcbfd0832bbff7700e2a7a255a