### PR TITLE
Add Gemini document parsing support

### DIFF
--- a/src/hooks/useGeminiAssistant.ts
+++ b/src/hooks/useGeminiAssistant.ts
@@ -28,7 +28,7 @@ export const useGeminiAssistant = () => {
       
       const { data, error } = await supabase.functions.invoke('gemini-assistant', {
         body: {
-          action: 'generate_carta_porte_data',
+          operation: 'generate_carta_porte_data',
           prompt,
           context
         },
@@ -66,7 +66,7 @@ export const useGeminiAssistant = () => {
     try {
       const { data, error } = await supabase.functions.invoke('gemini-assistant', {
         body: {
-          action: 'suggest_description',
+          operation: 'suggest_description',
           prompt: claveProducto
         },
       });
@@ -87,7 +87,7 @@ export const useGeminiAssistant = () => {
     try {
       const { data, error } = await supabase.functions.invoke('gemini-assistant', {
         body: {
-          action: 'validate_mercancia',
+          operation: 'validate_mercancia',
           data: mercanciaData
         },
       });
@@ -112,7 +112,7 @@ export const useGeminiAssistant = () => {
 
       const { data, error } = await supabase.functions.invoke('gemini-assistant', {
         body: {
-          action: 'improve_description',
+          operation: 'improve_description',
           prompt
         },
       });
@@ -133,7 +133,7 @@ export const useGeminiAssistant = () => {
     try {
       const { data, error } = await supabase.functions.invoke('gemini-assistant', {
         body: {
-          action: 'parse_document',
+          operation: 'parse_document',
           data: { text: documentText, document_type: documentType }
         },
       });

--- a/supabase/functions/gemini-assistant/index.ts
+++ b/supabase/functions/gemini-assistant/index.ts
@@ -80,6 +80,19 @@ serve(async (req) => {
         `;
         break;
 
+      case 'parse_document':
+        prompt = `
+        Analiza el siguiente texto de un documento tipo ${data.document_type || 'desconocido'}
+        y extrae la lista de mercancías mencionadas.
+
+        Texto del documento:
+        ${data.text}
+
+        Responde SOLO un JSON válido:
+        {"result": {"mercancias": [{"descripcion": "desc", "cantidad": 1, "claveProdServ": "00000000", "claveUnidad": "H87", "peso_kg": 0, "valor_mercancia": 0, "moneda": "MXN"}], "confidence": 0.8, "suggestions": ["mejora"]}}
+        `;
+        break;
+
       default:
         throw new Error(`Operation ${op} not supported`);
     }


### PR DESCRIPTION
## Summary
- add `parse_document` operation in Gemini edge function
- standardize client calls to use `operation` field

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684d0cf47ea4832b8f9f6adbaa917441