### PR TITLE
Implement document processing logs

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -939,6 +939,42 @@ export type Database = {
         }
         Relationships: []
       }
+      documentos_procesados: {
+        Row: {
+          id: string
+          file_path: string
+          extracted_text: string | null
+          confidence: number | null
+          mercancias_count: number | null
+          errors: string | null
+          carta_porte_id: string | null
+          documento_original_id: string | null
+          created_at: string | null
+        }
+        Insert: {
+          id?: string
+          file_path: string
+          extracted_text?: string | null
+          confidence?: number | null
+          mercancias_count?: number | null
+          errors?: string | null
+          carta_porte_id?: string | null
+          documento_original_id?: string | null
+          created_at?: string | null
+        }
+        Update: {
+          id?: string
+          file_path?: string
+          extracted_text?: string | null
+          confidence?: number | null
+          mercancias_count?: number | null
+          errors?: string | null
+          carta_porte_id?: string | null
+          documento_original_id?: string | null
+          created_at?: string | null
+        }
+        Relationships: []
+      }
       eventos_calendario: {
         Row: {
           carta_porte_id: string | null

--- a/supabase/migrations/20250614055801-add-documentos-procesados.sql
+++ b/supabase/migrations/20250614055801-add-documentos-procesados.sql
@@ -1,0 +1,19 @@
+CREATE TABLE public.documentos_procesados (
+  id UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+  file_path TEXT NOT NULL,
+  extracted_text TEXT,
+  confidence NUMERIC,
+  mercancias_count INTEGER,
+  errors TEXT,
+  carta_porte_id UUID,
+  documento_original_id UUID,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.documentos_procesados ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can insert documentos_procesados" ON public.documentos_procesados
+  FOR INSERT WITH CHECK (true);
+
+CREATE POLICY "Users can view documentos_procesados" ON public.documentos_procesados
+  FOR SELECT USING (true);


### PR DESCRIPTION
## Summary
- add `documentos_procesados` table definition and migration
- log processed documents from all document handlers
- support optional cartaPorteId and documentoOriginalId

## Testing
- `npm run lint` *(fails: Cannot resolve many TS rules)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684d0eeee1b4832babb4de652cd6c846