### PR TITLE
Use pdfjs for PDF extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,11 @@ pm2 monit
 # Restart aplicación
 pm2 restart trucking-api
 
+## Extracción de texto de PDFs
+
+Usamos **pdfjs-dist** para leer cada página y extraer el texto de forma fiable.
+La configuración del *worker* se realiza al inicio de `DocumentProcessor`.
+
 ## Flujo simplificado de Carta Porte
 
 Para depurar o probar el formulario sin las optimizaciones completas puedes activar un modo simplificado.

--- a/src/services/documentProcessor.ts
+++ b/src/services/documentProcessor.ts
@@ -1,11 +1,12 @@
 
 import Tesseract from 'tesseract.js';
 import { GlobalWorkerOptions, getDocument } from 'pdfjs-dist';
-import pdfWorker from 'pdfjs-dist/build/pdf.worker.min?worker';
+import pdfWorker from 'pdfjs-dist/build/pdf.worker.min?worker&inline';
 import { supabase } from '@/integrations/supabase/client';
 import { Mercancia } from '@/hooks/useMercancias';
 import { ExcelParser, defaultColumnMapping } from '@/utils/excelParser';
 
+// Configure worker for pdfjs to enable proper text extraction
 GlobalWorkerOptions.workerSrc = pdfWorker;
 
 export interface DocumentProcessingResult {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,4 +19,13 @@ export default defineConfig(({ mode }) => ({
       "@": path.resolve(__dirname, "./src"),
     },
   },
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          pdfjs: ["pdfjs-dist"],
+        },
+      },
+    },
+  },
 }));


### PR DESCRIPTION
## Summary
- use inline pdfjs worker for document processor
- explain pdf text extraction in README
- split pdfjs into its own chunk via Vite config

## Testing
- `npm run build` *(fails: Bus error)*

------
https://chatgpt.com/codex/tasks/task_e_684d0ef17f54832b89991220e8189776