### PR TITLE
Update README about pdfjs

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,11 @@ pm2 start ecosystem.config.js --env production
 
 # Actualizar Nginx
 sudo nginx -t && sudo systemctl reload nginx
+
+Extracción de PDFs
+Para procesar documentos en este formato utilizamos la librería `pdfjs-dist`,
+que extrae el texto de cada página de forma individual. El worker se configura
+al inicio de `DocumentProcessor` para asegurar su correcto funcionamiento.
 Variables de Entorno Requeridas
 env# Base de datos
 DATABASE_URL=postgresql://usuario:password@host:puerto/dbname


### PR DESCRIPTION
## Summary
- explain that pdfjs-dist extracts text page by page
- note that the pdf worker is configured at the start of DocumentProcessor

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684d13100758832b801336567ebc6f49