### PR TITLE
Invalidate cartas-porte cache on save

### DIFF
--- a/src/hooks/carta-porte/useCartaPorteFormManager.ts
+++ b/src/hooks/carta-porte/useCartaPorteFormManager.ts
@@ -10,6 +10,7 @@ import { useCartaPorteAutoSave } from './useCartaPorteAutoSave';
 import { useBorradorRecovery } from './useBorradorRecovery';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '../useAuth';
+import { useQueryClient } from '@tanstack/react-query';
 
 // Estado inicial unificado y por defecto
 const initialCartaPorteData: CartaPorteData = {
@@ -55,6 +56,7 @@ const deserializeCartaPorteData = (jsonData: any): CartaPorteData => {
 export function useCartaPorteFormManager(cartaPorteId?: string) {
   const { user } = useAuth();
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const [formData, setFormData] = useState<CartaPorteData>(initialCartaPorteData);
   const [currentStep, setCurrentStep] = useState(0);
   const [currentCartaPorteId, setCurrentCartaPorteId] = useState<string | null>(cartaPorteId || null);
@@ -338,7 +340,8 @@ export function useCartaPorteFormManager(cartaPorteId?: string) {
       
       setUltimoGuardado(new Date());
       toast.success('Carta porte guardada correctamente');
-      
+      queryClient.invalidateQueries({ queryKey: ['cartas-porte', user?.id] });
+
       return savedId;
     } catch (error) {
       console.error('❌ Error guardando carta porte:', error);
@@ -347,7 +350,7 @@ export function useCartaPorteFormManager(cartaPorteId?: string) {
     } finally {
       setIsGuardando(false);
     }
-  }, [formData, currentStep, xmlGenerado, datosCalculoRuta, currentCartaPorteId, user?.id, isGuardando]);
+  }, [formData, currentStep, xmlGenerado, datosCalculoRuta, currentCartaPorteId, user?.id, isGuardando, queryClient]);
 
   // Guardar y salir mejorado con navegación React Router CORREGIDO  
   const handleGuardarYSalir = useCallback(async () => {
@@ -358,7 +361,8 @@ export function useCartaPorteFormManager(cartaPorteId?: string) {
       if (savedId) {
         // Limpiar datos de sesión ya que se guardó exitosamente
         clearSessionData();
-        
+        queryClient.invalidateQueries({ queryKey: ['cartas-porte', user?.id] });
+
         // Usar navegación React Router
         toast.success('Carta porte guardada exitosamente');
         
@@ -372,7 +376,7 @@ export function useCartaPorteFormManager(cartaPorteId?: string) {
       console.error('❌ Error guardando carta porte:', error);
       toast.error('Error al guardar. No se puede salir. Verifica los datos.');
     }
-  }, [handleGuardarCartaPorteOficial, navigate, clearSessionData]);
+  }, [handleGuardarCartaPorteOficial, navigate, clearSessionData, queryClient, user?.id]);
 
   // Lógica de borrador (mantenido para compatibilidad)
   const handleGuardarBorrador = useCallback(async () => {


### PR DESCRIPTION
## Summary
- refresh cartas-porte list after saving a new record
- update Carta Porte form manager to use React Query cache

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx -y vitest run` *(fails: Cannot find package 'vite' imported in vitest.config.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68523da95bd0832b9ec211d8a44aa0c5