### PR TITLE
Use env vars for Supabase client

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,23 @@
+VITE_SUPABASE_URL=
+VITE_SUPABASE_KEY=
+
+# Base de datos
+DATABASE_URL=postgresql://usuario:password@host:puerto/dbname
+
+# APIs de IA
+OPENAI_API_KEY=tu_clave_openai
+CLAUDE_API_KEY=tu_clave_claude
+
+# WhatsApp Business
+WHATSAPP_API_KEY=tu_clave_whatsapp
+WHATSAPP_WEBHOOK_URL=tu_webhook_url
+
+# Google Services
+GOOGLE_API_KEY=tu_clave_google
+GOOGLE_CLIENT_ID=tu_client_id
+
+# Entorno
+NODE_ENV=production
+PORT=8091
+
+VITE_SIMPLIFIED_CARTA_PORTE=false

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ npm install
 
 # Paso 4: Configurar variables de entorno
 cp .env.example .env
-# Editar .env con tus configuraciones de APIs y base de datos
+# Editar .env con tus configuraciones de Supabase, APIs y base de datos
 
 # Paso 5: Iniciar servidor de desarrollo
 npm run dev
@@ -108,6 +108,10 @@ al inicio de `DocumentProcessor` para asegurar su correcto funcionamiento.
 Variables de Entorno Requeridas
 env# Base de datos
 DATABASE_URL=postgresql://usuario:password@host:puerto/dbname
+
+# Supabase
+VITE_SUPABASE_URL=tu_url_supabase
+VITE_SUPABASE_KEY=tu_clave_supabase
 
 # APIs de IA
 OPENAI_API_KEY=tu_clave_openai

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -2,8 +2,8 @@
 import { createClient } from '@supabase/supabase-js';
 import type { Database } from './types';
 
-const SUPABASE_URL = "https://qulhweffinppyjpfkknh.supabase.co";
-const SUPABASE_PUBLISHABLE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InF1bGh3ZWZmaW5wcHlqcGZra25oIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDk2MTg3ODEsImV4cCI6MjA2NTE5NDc4MX0.7MwqHsoSSdlzizarradrdMGUHG9QuXyIGFXd0imNrMM";
+const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL as string;
+const SUPABASE_PUBLISHABLE_KEY = import.meta.env.VITE_SUPABASE_KEY as string;
 
 // Import the supabase client like this:
 // import { supabase } from "@/integrations/supabase/client";

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,6 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_SUPABASE_URL: string;
+  readonly VITE_SUPABASE_KEY: string;
+}


### PR DESCRIPTION
## Summary
- load Supabase credentials from `import.meta.env`
- document new variables in README
- provide `.env.example` template
- extend Vite env typings

## Testing
- `npm run lint` *(fails: Unexpected any, prefer-const, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68523daa38b8832bb3ca298f778e1765