### PR TITLE
Remove fallback Mapbox token

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,21 @@
+# Base de datos
+DATABASE_URL=postgresql://usuario:password@host:puerto/dbname
+
+# APIs de IA
+OPENAI_API_KEY=tu_clave_openai
+CLAUDE_API_KEY=tu_clave_claude
+
+# WhatsApp Business
+WHATSAPP_API_KEY=tu_clave_whatsapp
+WHATSAPP_WEBHOOK_URL=tu_webhook_url
+
+# Google Services
+GOOGLE_API_KEY=tu_clave_google
+GOOGLE_CLIENT_ID=tu_client_id
+
+# Mapbox
+VITE_MAPBOX_TOKEN=your_mapbox_token_here
+
+# Entorno
+NODE_ENV=production
+PORT=8091

--- a/src/services/mapService.ts
+++ b/src/services/mapService.ts
@@ -1,7 +1,7 @@
 import mapboxgl from 'mapbox-gl';
 
 // Mapbox access token
-const MAPBOX_ACCESS_TOKEN = import.meta.env.VITE_MAPBOX_TOKEN || 'pk.eyJ1IjoiaW50ZXJjb25lY3RhIiwiYSI6ImNtYndqcWFyajExYTIya3B1NG1oaXJ2YjIifQ.OVtTgnmv6ZA3En2trhim-Q';
+const MAPBOX_ACCESS_TOKEN = import.meta.env.VITE_MAPBOX_TOKEN;
 
 export interface Coordinates {
   lat: number;
@@ -39,7 +39,7 @@ class MapService {
 
   // Check if Mapbox token is configured
   isConfigured(): boolean {
-    return this.accessToken !== 'your-mapbox-token-here' && this.accessToken.length > 0;
+    return typeof this.accessToken === 'string' && this.accessToken.length > 0;
   }
 
   // Geocodificar una dirección a coordenadas


### PR DESCRIPTION
## Summary
- remove embedded Mapbox token and read from VITE_MAPBOX_TOKEN
- detect empty token in MapService
- add example VITE_MAPBOX_TOKEN to .env.example

## Testing
- `npm run lint` *(fails: many lint errors but command executed)*

------
https://chatgpt.com/codex/tasks/task_e_68523dab3718832b82c2107c791fba7b