### PR TITLE
Add user and tenant info to Carta Porte drafts

### DIFF
--- a/src/hooks/carta-porte/useCartaPorteAutoSave.ts
+++ b/src/hooks/carta-porte/useCartaPorteAutoSave.ts
@@ -9,13 +9,17 @@ interface UseCartaPorteAutoSaveOptions {
   currentCartaPorteId?: string;
   onCartaPorteIdChange?: (id: string) => void;
   enabled?: boolean;
+  userId?: string;
+  tenantId?: string;
 }
 
-export const useCartaPorteAutoSave = ({ 
-  formData, 
+export const useCartaPorteAutoSave = ({
+  formData,
   currentCartaPorteId,
   onCartaPorteIdChange,
-  enabled = true
+  enabled = true,
+  userId,
+  tenantId
 }: UseCartaPorteAutoSaveOptions) => {
   const [isAutoSaving, setIsAutoSaving] = useState(false);
   const [lastSaved, setLastSaved] = useState<Date | null>(null);
@@ -43,7 +47,12 @@ export const useCartaPorteAutoSave = ({
     
     setIsAutoSaving(true);
     try {
-      const nuevoId = await BorradorService.guardarBorrador(formData, currentCartaPorteId);
+      const nuevoId = await BorradorService.guardarBorrador(
+        formData,
+        currentCartaPorteId,
+        userId,
+        tenantId
+      );
       
       if (nuevoId && nuevoId !== currentCartaPorteId && onCartaPorteIdChange) {
         onCartaPorteIdChange(nuevoId);
@@ -57,7 +66,7 @@ export const useCartaPorteAutoSave = ({
     } finally {
       setIsAutoSaving(false);
     }
-  }, [formData, currentCartaPorteId, enabled, isAutoSaving, onCartaPorteIdChange]);
+  }, [formData, currentCartaPorteId, enabled, isAutoSaving, onCartaPorteIdChange, userId, tenantId]);
 
   // Efecto para auto-guardado con debounce
   useEffect(() => {
@@ -83,7 +92,12 @@ export const useCartaPorteAutoSave = ({
     const handleBeforeUnload = (e: BeforeUnloadEvent) => {
       if (enabled && formData) {
         // Intentar guardado síncrono antes de salir
-        BorradorService.guardarBorradorAutomatico(formData, currentCartaPorteId);
+        BorradorService.guardarBorradorAutomatico(
+          formData,
+          currentCartaPorteId,
+          userId,
+          tenantId
+        );
         e.preventDefault();
         e.returnValue = '¿Estás seguro de que quieres salir? Los cambios no guardados se perderán.';
       }
@@ -91,7 +105,7 @@ export const useCartaPorteAutoSave = ({
 
     window.addEventListener('beforeunload', handleBeforeUnload);
     return () => window.removeEventListener('beforeunload', handleBeforeUnload);
-  }, [formData, currentCartaPorteId, enabled]);
+  }, [formData, currentCartaPorteId, enabled, userId, tenantId]);
 
   // Función para forzar guardado manual
   const forceSave = useCallback(async () => {

--- a/src/hooks/carta-porte/useCartaPorteFormManager.ts
+++ b/src/hooks/carta-porte/useCartaPorteFormManager.ts
@@ -85,7 +85,9 @@ export function useCartaPorteFormManager(cartaPorteId?: string) {
     },
     currentCartaPorteId: currentCartaPorteId || undefined,
     onCartaPorteIdChange: (id) => setCurrentCartaPorteId(id),
-    enabled: true
+    enabled: true,
+    userId: user?.id,
+    tenantId: user?.usuario?.tenant_id
   });
 
   // Recuperación de borrador
@@ -304,6 +306,7 @@ export function useCartaPorteFormManager(cartaPorteId?: string) {
         status: xmlGenerado ? 'generado' : 'borrador',
         datos_formulario: serializedData as any, // Cast para evitar error de tipo
         usuario_id: user.id,
+        tenant_id: user.usuario?.tenant_id,
         created_at: new Date().toISOString(),
         updated_at: new Date().toISOString()
       };
@@ -391,7 +394,12 @@ export function useCartaPorteFormManager(cartaPorteId?: string) {
         datosCalculoRuta
       };
       
-      const nuevoId = await BorradorService.guardarBorrador(datosCompletos, currentCartaPorteId || undefined);
+      const nuevoId = await BorradorService.guardarBorrador(
+        datosCompletos,
+        currentCartaPorteId || undefined,
+        user?.id,
+        user?.usuario?.tenant_id
+      );
       
       if (nuevoId && nuevoId !== currentCartaPorteId) {
         setCurrentCartaPorteId(nuevoId);


### PR DESCRIPTION
## Summary
- include `usuario_id` and `tenant_id` when saving drafts in `borradorService`
- allow passing user/tenant ids in `useCartaPorteAutoSave`
- forward the ids from `useCartaPorteFormManager`
- store tenant id when saving a Carta Porte officially

## Testing
- `npm test --silent` *(fails: supabaseUrl is required)*
- `npm run lint` *(fails: 604 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6852412f894c832b9953be5222552278