### PR TITLE
Fix: hide TruckAnimation notifications on mobile

### DIFF
--- a/src/components/landing/TruckAnimation.tsx
+++ b/src/components/landing/TruckAnimation.tsx
@@ -116,21 +116,21 @@ const TruckAnimation = () => {
       </div>
 
       {/* Floating Notifications - Fuera del contenedor principal */}
-      <div className="absolute top-16 right-0 z-30 space-y-3 transform translate-x-8">
+      <div className="absolute top-16 right-0 z-30 space-y-3 transform translate-x-8 hidden md:block">
         <div className="bg-white p-3 rounded-xl shadow-lg border border-gray-200 flex items-center gap-3 min-w-[280px] animate-slide-in-right">
           <div className="w-2 h-2 rounded-full bg-green-500"></div>
           <span className="text-sm font-medium text-gray-700">✅ Carta porte CP-2847 timbrada</span>
         </div>
       </div>
 
-      <div className="absolute top-32 left-0 z-30 space-y-3 transform -translate-x-8">
+      <div className="absolute top-32 left-0 z-30 space-y-3 transform -translate-x-8 hidden md:block">
         <div className="bg-white p-3 rounded-xl shadow-lg border border-gray-200 flex items-center gap-3 min-w-[280px] animate-slide-in-right" style={{ animationDelay: '2s' }}>
           <div className="w-2 h-2 rounded-full bg-blue-500"></div>
           <span className="text-sm font-medium text-gray-700">🚛 TRK-005 en ruta a Guadalajara</span>
         </div>
       </div>
 
-      <div className="absolute bottom-20 right-0 z-30 space-y-3 transform translate-x-8">
+      <div className="absolute bottom-20 right-0 z-30 space-y-3 transform translate-x-8 hidden md:block">
         <div className="bg-white p-3 rounded-xl shadow-lg border border-gray-200 flex items-center gap-3 min-w-[280px] animate-slide-in-right" style={{ animationDelay: '4s' }}>
           <div className="w-2 h-2 rounded-full bg-yellow-500"></div>
           <span className="text-sm font-medium text-gray-700">💡 IA sugiere ruta optimizada</span>


### PR DESCRIPTION
## Summary
- hide floating notification bubbles for CP-2847, TRK-005 and the AI suggestion when on mobile screens

## Testing
- `npm run lint` *(fails: 603 errors, 45 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6852c8d74990832ba733b73700ee9ed4