### PR TITLE
Add Fiscal API invoice service

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,3 +206,7 @@ Para mantener la calidad del código:
 - Mantén los componentes pequeños y focalizados
 
 ¡Listo para automatizar el transporte de carga con Interconecta Trucking! 🚛📋✨
+
+## Integracion con FISCAL API
+
+Se incluye el servicio `FiscalApiService` para emitir CFDI 4.0 y complementar con Carta Porte 3.1 utilizando FISCAL API. Configure las llaves en `.env` y llame a la función edge `timbrar-invoice` o use el servicio directamente desde el frontend.

--- a/src/services/fiscal/FiscalApiService.ts
+++ b/src/services/fiscal/FiscalApiService.ts
@@ -1,0 +1,82 @@
+export type FiscalApiEnvironment = 'sandbox' | 'production';
+
+export interface FiscalApiResponse {
+  success: boolean;
+  data?: any;
+  error?: string;
+}
+
+export class FiscalApiService {
+  private baseUrl: string;
+
+  constructor(private apiKey: string, environment: FiscalApiEnvironment = 'sandbox') {
+    this.baseUrl =
+      environment === 'production'
+        ? 'https://api.fiscalapi.com'
+        : 'https://api-sandbox.fiscalapi.com';
+  }
+
+  async createInvoice(invoiceData: any): Promise<FiscalApiResponse> {
+    return this.request('/v1/cfdi/stamp', invoiceData);
+  }
+
+  async createInvoiceWithCartaPorte(invoiceData: any, cartaPorteData: any): Promise<FiscalApiResponse> {
+    const payload = { ...invoiceData, Complemento: { CartaPorte31: cartaPorteData } };
+    return this.request('/v1/cfdi/stamp', payload);
+  }
+
+  async cancelInvoice(invoiceId: string): Promise<FiscalApiResponse> {
+    return this.request(`/v1/cfdi/${invoiceId}`, undefined, 'DELETE');
+  }
+
+  async getInvoice(invoiceId: string): Promise<FiscalApiResponse> {
+    return this.request(`/v1/cfdi/${invoiceId}`, undefined, 'GET');
+  }
+
+  async downloadPdf(invoiceId: string): Promise<string> {
+    const res = await this.rawRequest(`/v1/cfdi/${invoiceId}/pdf`, 'GET');
+    return await res.text();
+  }
+
+  async downloadXml(invoiceId: string): Promise<string> {
+    const res = await this.rawRequest(`/v1/cfdi/${invoiceId}/xml`, 'GET');
+    return await res.text();
+  }
+
+  async validateTaxInfo(rfc: string): Promise<boolean> {
+    const resp = await this.request('/v1/tax/validate', { rfc });
+    return resp.success;
+  }
+
+  async getInvoiceStatus(invoiceId: string): Promise<string> {
+    const resp = await this.request(`/v1/cfdi/${invoiceId}/status`, undefined, 'GET');
+    if (resp.success) return resp.data.status;
+    throw new Error(resp.error || 'Unknown error');
+  }
+
+  private async request(path: string, data?: any, method: string = 'POST'): Promise<FiscalApiResponse> {
+    try {
+      const res = await this.rawRequest(path, method, data);
+      if (!res.ok) {
+        const errText = await res.text();
+        return { success: false, error: errText };
+      }
+      const json = await res.json();
+      return { success: true, data: json };
+    } catch (error) {
+      return { success: false, error: (error as Error).message };
+    }
+  }
+
+  private async rawRequest(path: string, method: string = 'POST', data?: any): Promise<Response> {
+    const url = `${this.baseUrl}${path}`;
+    return fetch(url, {
+      method,
+      headers: {
+        'Authorization': `Bearer ${this.apiKey}`,
+        'Content-Type': 'application/json'
+      },
+      body: data ? JSON.stringify(data) : undefined
+    });
+  }
+}

--- a/src/tests/FiscalApiService.test.ts
+++ b/src/tests/FiscalApiService.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test, vi } from 'vitest';
+import { FiscalApiService } from '@/services/fiscal/FiscalApiService';
+
+vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => ({ id: '123' }) })));
+
+describe('FiscalApiService', () => {
+  test('createInvoice calls API', async () => {
+    const service = new FiscalApiService('key');
+    const result = await service.createInvoice({});
+    expect(result.success).toBe(true);
+    expect((fetch as any).mock.calls.length).toBe(1);
+  });
+});

--- a/supabase/functions/timbrar-invoice/index.ts
+++ b/supabase/functions/timbrar-invoice/index.ts
@@ -1,0 +1,49 @@
+import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};
+
+const handler = async (req: Request): Promise<Response> => {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  try {
+    const fiscalApiKey = Deno.env.get('FISCAL_API_KEY');
+    if (!fiscalApiKey) throw new Error('FISCAL_API_KEY not configured');
+
+    const invoiceData = await req.json();
+
+    const response = await fetch('https://api.fiscalapi.com/v1/cfdi/stamp', {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${fiscalApiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(invoiceData),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      return new Response(
+        JSON.stringify({ success: false, error: errorText }),
+        { status: 400, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+      );
+    }
+
+    const data = await response.json();
+    return new Response(
+      JSON.stringify({ success: true, data }),
+      { status: 200, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+    );
+  } catch (error) {
+    return new Response(
+      JSON.stringify({ success: false, error: error instanceof Error ? error.message : 'unknown error' }),
+      { status: 500, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+    );
+  }
+};
+
+serve(handler);


### PR DESCRIPTION
## Summary
- add `FiscalApiService` for CFDI & Carta Porte operations
- edge function `timbrar-invoice` to stamp invoices through Fiscal API
- basic unit test for the service
- document Fiscal API integration in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: missing dependencies 'jsdom' and '@vitest/coverage-v8')*

------
https://chatgpt.com/codex/tasks/task_e_6852f62a70e4832bbc6c7857dd280bf3