### PR TITLE
Add Ubicacion mapping for PDF/XML generation

### DIFF
--- a/src/hooks/carta-porte/mapUbicacionToCompleta.ts
+++ b/src/hooks/carta-porte/mapUbicacionToCompleta.ts
@@ -1,0 +1,38 @@
+import { Ubicacion } from '@/types/ubicaciones';
+import { UbicacionCompleta } from '@/types/cartaPorte';
+
+/**
+ * Convierte una ubicaci\u00f3n del formato usado en los formularios
+ * al formato completo requerido por el generador de XML/PDF.
+ */
+export function mapUbicacionToCompleta(ubicacion: Ubicacion): UbicacionCompleta {
+  return {
+    id: ubicacion.id,
+    tipo_ubicacion: ubicacion.tipoUbicacion,
+    id_ubicacion: ubicacion.idUbicacion,
+    rfc_remitente_destinatario: ubicacion.rfcRemitenteDestinatario,
+    nombre_remitente_destinatario: ubicacion.nombreRemitenteDestinatario,
+    fecha_hora_salida_llegada: ubicacion.fechaHoraSalidaLlegada,
+    distancia_recorrida: ubicacion.distanciaRecorrida,
+    tipo_estacion: (ubicacion as any).tipoEstacion,
+    numero_estacion: (ubicacion as any).numeroEstacion,
+    kilometro: (ubicacion as any).kilometro,
+    coordenadas: ubicacion.coordenadas
+      ? {
+          latitud: (ubicacion.coordenadas as any).latitud ?? ubicacion.coordenadas.lat ?? 0,
+          longitud: (ubicacion.coordenadas as any).longitud ?? ubicacion.coordenadas.lng ?? 0,
+        }
+      : undefined,
+    domicilio: {
+      pais: ubicacion.domicilio.pais,
+      codigo_postal: ubicacion.domicilio.codigoPostal,
+      estado: ubicacion.domicilio.estado,
+      municipio: ubicacion.domicilio.municipio,
+      colonia: ubicacion.domicilio.colonia,
+      calle: ubicacion.domicilio.calle,
+      numero_exterior: ubicacion.domicilio.numExterior || '',
+      numero_interior: ubicacion.domicilio.numInterior,
+      referencia: ubicacion.domicilio.referencia,
+    },
+  };
+}

--- a/src/hooks/carta-porte/useCartaPorteFormManager.ts
+++ b/src/hooks/carta-porte/useCartaPorteFormManager.ts
@@ -2,6 +2,8 @@
 import { useState, useCallback, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { CartaPorteData, AutotransporteCompleto, FiguraCompleta, MercanciaCompleta, UbicacionCompleta } from '@/types/cartaPorte';
+import { Ubicacion } from '@/types/ubicaciones';
+import { mapUbicacionToCompleta } from './mapUbicacionToCompleta';
 import { BorradorService } from '@/services/borradorService';
 import { useCartaPorteValidation } from './useCartaPorteValidation';
 import { useCartaPortePersistence } from './useCartaPortePersistence';
@@ -160,8 +162,11 @@ export function useCartaPorteFormManager(cartaPorteId?: string) {
   }, []);
 
   // Setters estables para cada sección del formulario
-  const setUbicaciones = useCallback((ubicaciones: UbicacionCompleta[]) => {
-    setFormData(prev => ({ ...prev, ubicaciones }));
+  const setUbicaciones = useCallback((ubicaciones: (Ubicacion | UbicacionCompleta)[]) => {
+    const completas = ubicaciones.map(ub =>
+      (ub as any).tipo_ubicacion ? (ub as UbicacionCompleta) : mapUbicacionToCompleta(ub as Ubicacion)
+    );
+    setFormData(prev => ({ ...prev, ubicaciones: completas }));
   }, []);
 
   const setMercancias = useCallback((mercancias: MercanciaCompleta[]) => {
@@ -270,6 +275,9 @@ export function useCartaPorteFormManager(cartaPorteId?: string) {
       // Preparar datos completos con estado actual
       const datosCompletos: CartaPorteData = {
         ...formData,
+        ubicaciones: (formData.ubicaciones || []).map(ub =>
+          (ub as any).tipo_ubicacion ? ub as UbicacionCompleta : mapUbicacionToCompleta(ub as Ubicacion)
+        ),
         currentStep,
         xmlGenerado,
         datosCalculoRuta
@@ -382,6 +390,9 @@ export function useCartaPorteFormManager(cartaPorteId?: string) {
     try {
       const datosCompletos: CartaPorteData = {
         ...formData,
+        ubicaciones: (formData.ubicaciones || []).map(ub =>
+          (ub as any).tipo_ubicacion ? ub as UbicacionCompleta : mapUbicacionToCompleta(ub as Ubicacion)
+        ),
         currentStep,
         xmlGenerado,
         datosCalculoRuta


### PR DESCRIPTION
## Summary
- add `mapUbicacionToCompleta` helper
- map ubicaciones when saving forms
- normalize ubicaciones before PDF and XML generation

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68531f1689a4832ba7e03b0ba7f81caf