### PR TITLE
Add distance and customs fields

### DIFF
--- a/src/components/carta-porte/configuracion/OpcionesEspeciales.tsx
+++ b/src/components/carta-porte/configuracion/OpcionesEspeciales.tsx
@@ -2,6 +2,7 @@ import React, { memo } from 'react';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Input } from '@/components/ui/input';
 import { CartaPorteData } from '@/types/cartaPorte';
 
 interface OpcionesEspecialesProps {
@@ -146,6 +147,28 @@ const OpcionesEspecialesComponent = ({ data, onChange }: OpcionesEspecialesProps
           </div>
         </div>
       )}
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 pt-4 border-t border-gray-200">
+        <div>
+          <Label htmlFor="total-dist-rec">Distancia Total Recorrida (km)</Label>
+          <Input
+            id="total-dist-rec"
+            type="number"
+            value={data.totalDistRec || ''}
+            onChange={e => handleFieldChange('totalDistRec', Number(e.target.value))}
+            placeholder="0"
+          />
+        </div>
+        <div>
+          <Label htmlFor="regimen-aduanero">Régimen Aduanero</Label>
+          <Input
+            id="regimen-aduanero"
+            value={data.regimenAduanero || ''}
+            onChange={e => handleFieldChange('regimenAduanero', e.target.value)}
+            placeholder="Regimen"
+          />
+        </div>
+      </div>
     </div>
   );
 };

--- a/src/hooks/carta-porte/useCartaPorteFormManager.ts
+++ b/src/hooks/carta-porte/useCartaPorteFormManager.ts
@@ -34,6 +34,8 @@ const initialCartaPorteData: CartaPorteData = {
     remolques: []
   },
   figuras: [],
+  totalDistRec: 0,
+  regimenAduanero: '',
   currentStep: 0,
   xmlGenerado: undefined,
   datosCalculoRuta: undefined,

--- a/src/hooks/useCartaPorteFormSimplified.ts
+++ b/src/hooks/useCartaPorteFormSimplified.ts
@@ -28,6 +28,8 @@ const initialData: CartaPorteData = {
     remolques: []
   },
   figuras: [],
+  totalDistRec: 0,
+  regimenAduanero: '',
 };
 
 // Validaciones básicas y estables

--- a/src/hooks/xml/useTimbrado.ts
+++ b/src/hooks/xml/useTimbrado.ts
@@ -18,7 +18,7 @@ export const useTimbrado = () => {
     setIsTimbring(true);
     try {
       // Validar XML antes del timbrado
-      const validacion = TimbradoService.validarXMLAntesDelTimbrado(xml);
+      const validacion = TimbradoService.validarXMLAntesDelTimbrado(xml, cartaPorteData);
       if (!validacion.isValid) {
         toast({
           title: "XML inválido para timbrado",

--- a/src/services/timbradoService.ts
+++ b/src/services/timbradoService.ts
@@ -1,5 +1,6 @@
 
 import { supabase } from '@/integrations/supabase/client';
+import { CartaPorteData } from '@/components/carta-porte/CartaPorteForm';
 
 export interface TimbradoRequest {
   xmlContent: string;
@@ -24,7 +25,7 @@ export interface TimbradoResponse {
 export class TimbradoService {
   private static readonly TIMBRADO_ENDPOINT = 'timbrar-carta-porte';
 
-  static validarXMLAntesDelTimbrado(xml: string): { isValid: boolean; errors: string[] } {
+  static validarXMLAntesDelTimbrado(xml: string, data?: CartaPorteData): { isValid: boolean; errors: string[] } {
     const errors: string[] = [];
 
     if (!xml.trim()) {
@@ -37,6 +38,15 @@ export class TimbradoService {
 
     if (!xml.includes('cfdi:Comprobante')) {
       errors.push('El XML no tiene la estructura de comprobante fiscal válida');
+    }
+
+    if (data) {
+      if (!data.totalDistRec) {
+        errors.push('TotalDistRec es obligatorio');
+      }
+      if (!data.regimenAduanero) {
+        errors.push('RegimenAduanero es obligatorio');
+      }
     }
 
     return {

--- a/src/services/xml/xmlComplemento.ts
+++ b/src/services/xml/xmlComplemento.ts
@@ -11,12 +11,14 @@ export class XMLComplementoBuilder {
 
   private static construirCartaPorte(data: CartaPorteData): string {
     const distanciaTotal = XMLUtils.calcularDistanciaTotal(data.ubicaciones || []);
-    
-    return `<cartaporte31:CartaPorte 
-      Version="3.1" 
+    const totalDist = data.totalDistRec || distanciaTotal;
+
+    return `<cartaporte31:CartaPorte
+      Version="3.1"
       TranspInternac="${data.transporteInternacional ? 'Sí' : 'No'}"
       ${data.transporteInternacional ? XMLUtils.construirAtributosInternacionales(data) : ''}
-      TotalDistRec="${distanciaTotal}">
+      TotalDistRec="${totalDist}"
+      ${data.regimenAduanero ? `RegimenAduanero="${data.regimenAduanero}"` : ''}>
       
       ${this.construirUbicaciones(data.ubicaciones || [])}
       ${this.construirMercancias(data.mercancias || [])}

--- a/src/services/xml/xmlUtils.ts
+++ b/src/services/xml/xmlUtils.ts
@@ -59,12 +59,13 @@ export const getUbicacionDestino = (data: any) => {
 export const buildComplementoCartaPorte = (data: any): string => {
   const origen = data.ubicaciones?.find((u: any) => u.tipo_ubicacion === 'Origen');
   const destino = data.ubicaciones?.find((u: any) => u.tipo_ubicacion === 'Destino');
-  
-  return `<cartaporte31:CartaPorte 
+
+  return `<cartaporte31:CartaPorte
     Version="3.1"
     TranspInternac="${data.transporteInternacional ? 'Sí' : 'No'}"
     EntradaSalidaMerc="${data.entradaSalidaMerc || 'Entrada'}"
     PaisOrigenDestino="${origen?.domicilio?.pais || 'MEX'}"
     ViaEntradaSalida="${destino?.domicilio?.pais || 'MEX'}"
-    TotalDistRec="${data.totalDistRec || 0}" />`;
+    TotalDistRec="${data.totalDistRec || 0}"
+    ${data.regimenAduanero ? `RegimenAduanero="${data.regimenAduanero}"` : ''} />`;
 };


### PR DESCRIPTION
## Summary
- capture `totalDistRec` and `regimenAduanero` in config forms
- include fields in XML builders
- validate fields before stamping

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68531bc842b8832b9ab95b6c9acce0d3