### PR TITLE
Add SAT catalog checks and coordinate validation

### DIFF
--- a/src/components/carta-porte/autotransporte/VehiculoPermits.tsx
+++ b/src/components/carta-porte/autotransporte/VehiculoPermits.tsx
@@ -1,9 +1,10 @@
 
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { CatalogoSelectorMejorado } from '@/components/catalogos/CatalogoSelectorMejorado';
 import { AutotransporteCompleto } from '@/types/cartaPorte';
+import { CatalogosSATService } from '@/services/catalogosSAT';
 
 interface VehiculoPermitsProps {
   data: AutotransporteCompleto;
@@ -14,6 +15,20 @@ interface VehiculoPermitsProps {
 }
 
 export function VehiculoPermits({ data, onFieldChange }: VehiculoPermitsProps) {
+  const [permisoError, setPermisoError] = useState('');
+
+  useEffect(() => {
+    const validar = async () => {
+      if (!data.perm_sct) {
+        setPermisoError('El tipo de permiso es requerido');
+        return;
+      }
+      const existe = await CatalogosSATService.existeTipoPermiso(data.perm_sct);
+      setPermisoError(existe ? '' : 'Permiso no válido');
+    };
+    validar();
+  }, [data.perm_sct]);
+
   return (
     <div className="space-y-4">
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -24,6 +39,7 @@ export function VehiculoPermits({ data, onFieldChange }: VehiculoPermitsProps) {
           onValueChange={(value) => onFieldChange('perm_sct', value)}
           placeholder="Buscar tipo de permiso..."
           required
+          error={permisoError}
         />
 
         <div className="space-y-2">

--- a/src/components/carta-porte/mercancias/MercanciaFormOptimizada.tsx
+++ b/src/components/carta-porte/mercancias/MercanciaFormOptimizada.tsx
@@ -1,5 +1,5 @@
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Package } from 'lucide-react';
@@ -7,6 +7,7 @@ import { MercanciaBasicInfo } from './MercanciaBasicInfo';
 import { MercanciaCantidades } from './MercanciaCantidades';
 import { MercanciaMaterialPeligroso } from './MercanciaMaterialPeligroso';
 import { MercanciaComercial } from './MercanciaComercial';
+import { CatalogosSATService } from '@/services/catalogosSAT';
 
 interface MercanciaFormOptimizadaProps {
   mercancia?: any;
@@ -40,6 +41,26 @@ export function MercanciaFormOptimizada({
 
   const [errors, setErrors] = React.useState<Record<string, string>>({});
   const [isLoading, setIsLoading] = React.useState(false);
+
+  useEffect(() => {
+    const validar = async () => {
+      if (formData.bienes_transp) {
+        const ok = await CatalogosSATService.existeProductoServicio(formData.bienes_transp);
+        setErrors(prev => ({ ...prev, bienes_transp: ok ? '' : 'Clave no válida' }));
+      }
+    };
+    validar();
+  }, [formData.bienes_transp]);
+
+  useEffect(() => {
+    const validar = async () => {
+      if (formData.clave_unidad) {
+        const ok = await CatalogosSATService.existeUnidad(formData.clave_unidad);
+        setErrors(prev => ({ ...prev, clave_unidad: ok ? '' : 'Unidad no válida' }));
+      }
+    };
+    validar();
+  }, [formData.clave_unidad]);
 
   const validateForm = () => {
     const newErrors: Record<string, string> = {};

--- a/src/components/carta-porte/ubicaciones/SmartUbicacionFormV2.tsx
+++ b/src/components/carta-porte/ubicaciones/SmartUbicacionFormV2.tsx
@@ -253,6 +253,19 @@ export function SmartUbicacionFormV2({
       newErrors.calle = 'La calle es requerida';
     }
 
+    if (formData.coordenadas) {
+      const { latitud, longitud } = formData.coordenadas;
+      if (latitud === undefined || isNaN(Number(latitud)) || Number(latitud) < -90 || Number(latitud) > 90) {
+        newErrors.latitud = 'Latitud inválida';
+      }
+      if (longitud === undefined || isNaN(Number(longitud)) || Number(longitud) < -180 || Number(longitud) > 180) {
+        newErrors.longitud = 'Longitud inválida';
+      }
+    } else {
+      newErrors.latitud = 'Latitud inválida';
+      newErrors.longitud = 'Longitud inválida';
+    }
+
     // Validar fecha y hora para origen y destino
     if ((formData.tipoUbicacion === 'Origen' || formData.tipoUbicacion === 'Destino') && 
         !formData.fechaHoraSalidaLlegada?.trim()) {
@@ -593,6 +606,37 @@ export function SmartUbicacionFormV2({
                     disabled={isFieldLocked('referencia')}
                     className={isFieldLocked('referencia') ? 'bg-gray-100' : 'bg-white'}
                   />
+                </div>
+              </div>
+
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div>
+                  <Label htmlFor="latitud">Latitud *</Label>
+                  <Input
+                    id="latitud"
+                    value={formData.coordenadas?.latitud ?? ''}
+                    onChange={(e) => {
+                      handleFieldChange('coordenadas.latitud', parseFloat(e.target.value));
+                      if (errors.latitud) setErrors(prev => ({ ...prev, latitud: '' }));
+                    }}
+                    placeholder="Ej: 19.4326"
+                    className={errors.latitud ? 'border-red-500' : ''}
+                  />
+                  {errors.latitud && <p className="text-sm text-red-500 mt-1">{errors.latitud}</p>}
+                </div>
+                <div>
+                  <Label htmlFor="longitud">Longitud *</Label>
+                  <Input
+                    id="longitud"
+                    value={formData.coordenadas?.longitud ?? ''}
+                    onChange={(e) => {
+                      handleFieldChange('coordenadas.longitud', parseFloat(e.target.value));
+                      if (errors.longitud) setErrors(prev => ({ ...prev, longitud: '' }));
+                    }}
+                    placeholder="Ej: -99.1332"
+                    className={errors.longitud ? 'border-red-500' : ''}
+                  />
+                  {errors.longitud && <p className="text-sm text-red-500 mt-1">{errors.longitud}</p>}
                 </div>
               </div>
             </div>

--- a/src/hooks/useMercancias.ts
+++ b/src/hooks/useMercancias.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { CatalogosSATService } from '@/services/catalogosSAT';
 
 export interface Mercancia {
   id?: string;
@@ -29,8 +30,8 @@ export const useMercancias = () => {
 
   const validarClaveMercancia = useCallback(async (clave: string): Promise<boolean> => {
     try {
-      // Mock validation - replace with real SAT validation
-      return clave.length >= 8;
+      if (!clave) return false;
+      return await CatalogosSATService.existeProductoServicio(clave);
     } catch (error) {
       console.error('Error validando clave de mercancía:', error);
       return false;
@@ -39,8 +40,8 @@ export const useMercancias = () => {
 
   const validarClaveUnidad = useCallback(async (clave: string): Promise<boolean> => {
     try {
-      // Mock validation - replace with real SAT validation  
-      return clave.length >= 3;
+      if (!clave) return false;
+      return await CatalogosSATService.existeUnidad(clave);
     } catch (error) {
       console.error('Error validando clave de unidad:', error);
       return false;

--- a/src/hooks/useUbicacionForm.ts
+++ b/src/hooks/useUbicacionForm.ts
@@ -56,6 +56,14 @@ export const useUbicacionForm = (initialData?: Partial<Ubicacion>, generarId?: (
             [keys[1]]: value
           }
         };
+      } else if (keys.length === 2 && keys[0] === 'coordenadas') {
+        return {
+          ...prev,
+          coordenadas: {
+            ...(prev.coordenadas || {}),
+            [keys[1]]: value
+          }
+        };
       }
       return prev;
     });

--- a/src/services/catalogosSAT.ts
+++ b/src/services/catalogosSAT.ts
@@ -113,6 +113,12 @@ export class CatalogosSATService {
     }
   }
 
+  // Verificar existencia de clave producto/servicio
+  static async existeProductoServicio(clave: string): Promise<boolean> {
+    const productos = await this.obtenerProductosServicios(clave);
+    return productos.some(p => p.clave === clave);
+  }
+
   // Obtener unidades de medida SAT
   static async obtenerUnidades(termino: string = ''): Promise<ClaveUnidad[]> {
     const cacheKey = this.getCacheKey('unidades', termino);
@@ -154,6 +160,12 @@ export class CatalogosSATService {
       console.error('Error in obtenerUnidades:', error);
       return [];
     }
+  }
+
+  // Verificar existencia de una unidad de medida
+  static async existeUnidad(clave: string): Promise<boolean> {
+    const unidades = await this.obtenerUnidades(clave);
+    return unidades.some(u => u.clave === clave);
   }
 
   // Obtener materiales peligrosos
@@ -302,6 +314,12 @@ export class CatalogosSATService {
       console.error('Error in obtenerTiposPermiso:', error);
       return [];
     }
+  }
+
+  // Verificar existencia de un tipo de permiso
+  static async existeTipoPermiso(clave: string): Promise<boolean> {
+    const permisos = await this.obtenerTiposPermiso();
+    return permisos.some(p => p.clave === clave);
   }
 
   // Obtener tipos de embalaje


### PR DESCRIPTION
## Summary
- verify catalog codes via `CatalogosSATService`
- check SAT products, units, and permissions in forms
- require latitude/longitude in `SmartUbicacionFormV2`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68531bca41a8832b908c782bd538f319