### PR TITLE
Add postal code geolocation service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Example environment variables
+# Geocoding API key for postal code lookups
+VITE_GEO_API_KEY=
+# Mapbox token for map services
+VITE_MAPBOX_TOKEN=

--- a/src/services/postalCodeGeoService.ts
+++ b/src/services/postalCodeGeoService.ts
@@ -1,0 +1,45 @@
+const GEO_API_KEY = import.meta.env.VITE_GEO_API_KEY || '';
+
+export interface PostalCodeCoordinates {
+  lat: number;
+  lng: number;
+}
+
+class PostalCodeGeoService {
+  private apiKey: string;
+
+  constructor(apiKey: string) {
+    this.apiKey = apiKey;
+  }
+
+  isConfigured(): boolean {
+    return this.apiKey.length > 0;
+  }
+
+  async getCoordinates(postalCode: string): Promise<PostalCodeCoordinates | null> {
+    if (!this.isConfigured()) return null;
+
+    try {
+      const resp = await fetch(
+        `https://maps.googleapis.com/maps/api/geocode/json?address=${encodeURIComponent(postalCode)}&key=${this.apiKey}`
+      );
+
+      if (!resp.ok) return null;
+
+      const data = await resp.json();
+      const result = data.results && data.results[0];
+      if (result && result.geometry && result.geometry.location) {
+        return {
+          lat: result.geometry.location.lat,
+          lng: result.geometry.location.lng
+        };
+      }
+    } catch (err) {
+      console.error('Geolocation API error:', err);
+    }
+
+    return null;
+  }
+}
+
+export const postalCodeGeoService = new PostalCodeGeoService(GEO_API_KEY);


### PR DESCRIPTION
## Summary
- implement PostalCodeGeoService to fetch lat/lng from Google Maps
- document geolocation API key in `.env.example`

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npx vitest run` *(fails: missing dependency 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_68531bca248c832bba2c3c040d836447