### PR TITLE
Fix folio persistence and postal code validation

### DIFF
--- a/src/components/carta-porte/xml/PDFGenerationPanel.tsx
+++ b/src/components/carta-porte/xml/PDFGenerationPanel.tsx
@@ -53,7 +53,8 @@ export function PDFGenerationPanel({
 
       // Encabezado
       addText('CARTA PORTE - COMPLEMENTO CFDI', 20, 18, 'bold');
-      addText(`Folio: CP-${Date.now().toString().slice(-8)}`, 20, 12);
+      const folio = cartaPorteData.folio || `CP-${Date.now().toString().slice(-8)}`;
+      addText(`Folio: ${folio}`, 20, 12);
       addText(`Fecha: ${new Date().toLocaleDateString('es-MX')}`, 20, 12);
       addSeparator();
 

--- a/src/hooks/carta-porte/useCartaPorteFormManager.ts
+++ b/src/hooks/carta-porte/useCartaPorteFormManager.ts
@@ -34,6 +34,7 @@ const initialCartaPorteData: CartaPorteData = {
     remolques: []
   },
   figuras: [],
+  folio: undefined,
   currentStep: 0,
   xmlGenerado: undefined,
   datosCalculoRuta: undefined,
@@ -114,7 +115,7 @@ export function useCartaPorteFormManager(cartaPorteId?: string) {
       console.log('🔄 Cargando datos de carta porte:', id);
       const { data, error } = await supabase
         .from('cartas_porte')
-        .select('datos_formulario')
+        .select('datos_formulario, folio')
         .eq('id', id)
         .single();
 
@@ -122,6 +123,9 @@ export function useCartaPorteFormManager(cartaPorteId?: string) {
 
       if (data?.datos_formulario) {
         const savedData = deserializeCartaPorteData(data.datos_formulario);
+        if (data.folio) {
+          savedData.folio = data.folio;
+        }
         
         console.log('✅ Datos cargados exitosamente:', {
           hasXML: !!savedData.xmlGenerado,
@@ -286,8 +290,12 @@ export function useCartaPorteFormManager(cartaPorteId?: string) {
       // Serialize data for Supabase - CORREGIDO
       const serializedData = serializeCartaPorteData(datosCompletos);
       
-      // Generar folio único si no existe
-      const folio = `CP-${Date.now().toString().slice(-8)}`;
+      // Generar folio único solo la primera vez
+      let folio = formData.folio;
+      if (!folio) {
+        folio = `CP-${Date.now().toString().slice(-8)}`;
+        setFormData(prev => ({ ...prev, folio }));
+      }
       
       // Preparar datos para la carta porte oficial - CORREGIDO tipos
       const cartaPorteData = {

--- a/src/services/pdfGenerator/CartaPortePDFAdvanced.tsx
+++ b/src/services/pdfGenerator/CartaPortePDFAdvanced.tsx
@@ -122,7 +122,7 @@ export class CartaPortePDFAdvanced {
   }
 
   private static addGeneralInfo(doc: jsPDF, data: CartaPorteData, yPosition: number, pageWidth: number): number {
-    const folio = `CP-${Date.now().toString().slice(-8)}`;
+    const folio = data.folio || `CP-${Date.now().toString().slice(-8)}`;
     
     this.addSectionTitle(doc, 'Información General', yPosition);
     yPosition += 10;

--- a/src/services/xml/xmlConceptos.ts
+++ b/src/services/xml/xmlConceptos.ts
@@ -37,6 +37,6 @@ export class XMLConceptosBuilder {
 
   private static obtenerCodigoPostalReceptor(data: CartaPorteData): string {
     const destino = data.ubicaciones?.find(u => u.tipo_ubicacion === 'Destino');
-    return destino?.domicilio?.codigo_postal || '01000';
+    return destino?.domicilio?.codigo_postal || '';
   }
 }

--- a/src/services/xml/xmlGenerator.ts
+++ b/src/services/xml/xmlGenerator.ts
@@ -44,7 +44,7 @@ export class XMLCartaPorteGenerator {
 
   private static construirXML(data: CartaPorteData): string {
     const fechaActual = new Date().toISOString();
-    const folio = XMLUtils.generarFolio();
+    const folio = data.folio || XMLUtils.generarFolio();
     const version = data.cartaPorteVersion || '3.1';
     
     // Obtener namespaces según versión

--- a/src/services/xml/xmlUtils.ts
+++ b/src/services/xml/xmlUtils.ts
@@ -11,12 +11,12 @@ export class XMLUtils {
 
   static obtenerCodigoPostalExpedicion(data: CartaPorteData): string {
     const origen = data.ubicaciones?.find(u => u.tipo_ubicacion === 'Origen');
-    return origen?.domicilio?.codigo_postal || '01000';
+    return origen?.domicilio?.codigo_postal || '';
   }
 
   static obtenerCodigoPostalReceptor(data: CartaPorteData): string {
     const destino = data.ubicaciones?.find(u => u.tipo_ubicacion === 'Destino');
-    return destino?.domicilio?.codigo_postal || '01000';
+    return destino?.domicilio?.codigo_postal || '';
   }
 
   static calcularDistanciaTotal(ubicaciones: UbicacionCompleta[]): number {
@@ -48,12 +48,12 @@ export class XMLUtils {
 
 export const getUbicacionOrigen = (data: any) => {
   const origen = data.ubicaciones?.find((u: any) => u.tipo_ubicacion === 'Origen');
-  return origen?.domicilio?.codigo_postal || '01000';
+  return origen?.domicilio?.codigo_postal || '';
 };
 
 export const getUbicacionDestino = (data: any) => {
   const destino = data.ubicaciones?.find((u: any) => u.tipo_ubicacion === 'Destino');
-  return destino?.domicilio?.codigo_postal || '01000';
+  return destino?.domicilio?.codigo_postal || '';
 };
 
 export const buildComplementoCartaPorte = (data: any): string => {

--- a/src/types/cartaPorte.ts
+++ b/src/types/cartaPorte.ts
@@ -20,6 +20,7 @@ export interface CartaPorteData {
   figuras?: FiguraCompleta[];
   pais_origen_destino?: string;
   via_entrada_salida?: string;
+  folio?: string;
   cartaPorteId?: string;
   
   // Campos para persistencia de estado


### PR DESCRIPTION
## Summary
- generate XML folio once and store it
- include folio when loading saved Carta Porte data
- show saved folio in PDF output
- remove default postal codes from XML utils

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js' etc.)*
- `npx vitest run` *(fails: useAuth must be used within an AuthProvider)*

------
https://chatgpt.com/codex/tasks/task_e_68531bca1fb0832ba14aef6e48dc9b68