### PR TITLE
Implement server PDF generation

### DIFF
--- a/src/components/cartas-porte/CartasPorteTableAdvanced.tsx
+++ b/src/components/cartas-porte/CartasPorteTableAdvanced.tsx
@@ -31,15 +31,17 @@ interface CartasPorteTableAdvancedProps {
   onDelete?: (id: string) => void;
   onRegenerateXML?: (id: string) => void;
   onGeneratePDF?: (id: string) => void;
+  pdfLinks?: Record<string, string>;
 }
 
-export function CartasPorteTableAdvanced({ 
-  cartasPorte, 
-  loading, 
-  onEdit, 
+export function CartasPorteTableAdvanced({
+  cartasPorte,
+  loading,
+  onEdit,
   onDelete,
   onRegenerateXML,
-  onGeneratePDF 
+  onGeneratePDF,
+  pdfLinks
 }: CartasPorteTableAdvancedProps) {
   const [selectedXML, setSelectedXML] = useState<string | null>(null);
   const [showXMLDialog, setShowXMLDialog] = useState(false);
@@ -251,6 +253,15 @@ export function CartasPorteTableAdvanced({
                         )}
                         PDF
                       </Button>
+                      {pdfLinks && pdfLinks[carta.id] && (
+                        <a
+                          href={pdfLinks[carta.id]}
+                          download={`carta-porte-${carta.folio || carta.id.slice(-8)}.pdf`}
+                          className="text-xs text-blue-600 underline"
+                        >
+                          Descargar
+                        </a>
+                      )}
 
                       <DropdownMenu>
                         <DropdownMenuTrigger asChild>

--- a/src/services/CartaPortePDFService.ts
+++ b/src/services/CartaPortePDFService.ts
@@ -1,0 +1,38 @@
+export interface CartaPortePDFResult {
+  success: boolean;
+  pdfBlob?: Blob;
+  pdfUrl?: string;
+  error?: string;
+}
+
+import { supabase } from '@/integrations/supabase/client';
+
+export class CartaPortePDFService {
+  private static readonly GENERATE_ENDPOINT = 'generar-pdf-carta-porte';
+
+  static async generate(id: string): Promise<CartaPortePDFResult> {
+    try {
+      const { data, error } = await supabase.functions.invoke(this.GENERATE_ENDPOINT, {
+        body: { id }
+      });
+
+      if (error) {
+        return { success: false, error: error.message };
+      }
+
+      if (!data || !data.pdfBase64) {
+        return { success: false, error: 'PDF no generado' };
+      }
+
+      const byteCharacters = atob(data.pdfBase64);
+      const byteNumbers = new Array(byteCharacters.length).fill(0).map((_, i) => byteCharacters.charCodeAt(i));
+      const pdfBlob = new Blob([new Uint8Array(byteNumbers)], { type: 'application/pdf' });
+      const pdfUrl = URL.createObjectURL(pdfBlob);
+
+      return { success: true, pdfBlob, pdfUrl };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Error desconocido generando PDF';
+      return { success: false, error: message };
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- create `CartaPortePDFService` to call Supabase function and return a PDF URL
- invoke `CartaPortePDFService.generate` in `CartasPorte` page and store resulting link
- display download link in `CartasPorteTableAdvanced`
- fallback to local `CartaPortePDFAdvanced` when server PDF generation fails

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68531bcc1004832bb6866a563b9c1f2a