### PR TITLE
Implement PAC integrations

### DIFF
--- a/src/services/pac/MultiplePACManager.ts
+++ b/src/services/pac/MultiplePACManager.ts
@@ -229,9 +229,9 @@ export class MultiplePACManager {
       case 'demo':
         return this.timbrarDemo(xml);
       case 'finkok':
-        return this.timbrarFinkok(xml, url, provider.config.credentials);
+        return this.timbrarFinkok(xml, url, provider.config.credentials, options.timeoutMs);
       case 'ecodex':
-        return this.timbrarEcodex(xml, url, provider.config.credentials);
+        return this.timbrarEcodex(xml, url, provider.config.credentials, options.timeoutMs);
       default:
         throw new Error(`Tipo de PAC no soportado: ${provider.type}`);
     }
@@ -303,14 +303,124 @@ export class MultiplePACManager {
     };
   }
 
-  private async timbrarFinkok(xml: string, url: string, credentials?: any): Promise<TimbradoResult> {
-    // TODO: Implement Finkok SOAP integration
-    throw new Error('Finkok integration not implemented yet');
+  private async timbrarFinkok(
+    xml: string,
+    url: string,
+    credentials: any = {},
+    timeoutMs: number = 30000
+  ): Promise<TimbradoResult> {
+    if (!credentials.username || !credentials.password) {
+      return { success: false, error: 'Credenciales Finkok incompletas' };
+    }
+
+    const xmlBase64 = btoa(unescape(encodeURIComponent(xml)));
+    const soapBody = `<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:tns="http://facturacion.finkok.com/stamp">
+  <soapenv:Body>
+    <tns:stamp>
+      <xml>${xmlBase64}</xml>
+      <username>${credentials.username}</username>
+      <password>${credentials.password}</password>
+    </tns:stamp>
+  </soapenv:Body>
+</soapenv:Envelope>`;
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+    try {
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'text/xml' },
+        body: soapBody,
+        signal: controller.signal
+      });
+      clearTimeout(timer);
+
+      if (!response.ok) {
+        return { success: false, error: `HTTP ${response.status}` };
+      }
+
+      const text = await response.text();
+      const parser = new DOMParser();
+      const doc = parser.parseFromString(text, 'text/xml');
+      const uuid = doc.getElementsByTagName('UUID')[0]?.textContent ||
+        doc.querySelector('tfd\\:TimbreFiscalDigital')?.getAttribute('UUID') || undefined;
+      const xmlTimbradoBase64 = doc.getElementsByTagName('xml')[0]?.textContent || '';
+      const xmlTimbrado = xmlTimbradoBase64 ? decodeURIComponent(escape(atob(xmlTimbradoBase64))) : undefined;
+
+      if (!uuid && !xmlTimbrado) {
+        const err = doc.getElementsByTagName('faultstring')[0]?.textContent || 'Error en Finkok';
+        return { success: false, error: err };
+      }
+
+      return { success: true, uuid, xmlTimbrado };
+    } catch (error: any) {
+      if (error.name === 'AbortError') {
+        return { success: false, error: 'Timeout' };
+      }
+      return { success: false, error: error.message };
+    }
   }
 
-  private async timbrarEcodex(xml: string, url: string, credentials?: any): Promise<TimbradoResult> {
-    // TODO: Implement Ecodex integration
-    throw new Error('Ecodex integration not implemented yet');
+  private async timbrarEcodex(
+    xml: string,
+    url: string,
+    credentials: any = {},
+    timeoutMs: number = 30000
+  ): Promise<TimbradoResult> {
+    if (!credentials.username || !credentials.password) {
+      return { success: false, error: 'Credenciales Ecodex incompletas' };
+    }
+
+    const xmlBase64 = btoa(unescape(encodeURIComponent(xml)));
+    const soapBody = `<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">
+  <soapenv:Body>
+    <timbrar xmlns="http://tempuri.org/">
+      <usuario>${credentials.username}</usuario>
+      <password>${credentials.password}</password>
+      <cfdi>${xmlBase64}</cfdi>
+    </timbrar>
+  </soapenv:Body>
+</soapenv:Envelope>`;
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+    try {
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'text/xml' },
+        body: soapBody,
+        signal: controller.signal
+      });
+      clearTimeout(timer);
+
+      if (!response.ok) {
+        return { success: false, error: `HTTP ${response.status}` };
+      }
+
+      const text = await response.text();
+      const parser = new DOMParser();
+      const doc = parser.parseFromString(text, 'text/xml');
+      const uuid = doc.getElementsByTagName('UUID')[0]?.textContent ||
+        doc.querySelector('tfd\\:TimbreFiscalDigital')?.getAttribute('UUID') || undefined;
+      const xmlTimbradoBase64 = doc.getElementsByTagName('xml')[0]?.textContent || '';
+      const xmlTimbrado = xmlTimbradoBase64 ? decodeURIComponent(escape(atob(xmlTimbradoBase64))) : undefined;
+
+      if (!uuid && !xmlTimbrado) {
+        const err = doc.getElementsByTagName('faultstring')[0]?.textContent || 'Error en Ecodex';
+        return { success: false, error: err };
+      }
+
+      return { success: true, uuid, xmlTimbrado };
+    } catch (error: any) {
+      if (error.name === 'AbortError') {
+        return { success: false, error: 'Timeout' };
+      }
+      return { success: false, error: error.message };
+    }
   }
 
   private updateProviderMetrics(providerId: string, success: boolean, responseTime: number) {

--- a/src/tests/PACIntegrations.test.ts
+++ b/src/tests/PACIntegrations.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test, vi, beforeEach, afterEach } from 'vitest';
+import { MultiplePACManager } from '@/services/pac/MultiplePACManager';
+
+const sampleXml = '<cfdi:Comprobante>test</cfdi:Comprobante>';
+
+let manager: MultiplePACManager;
+
+beforeEach(() => {
+  manager = new MultiplePACManager();
+  manager.updateProviderConfig('finkok', {
+    isActive: true,
+    healthStatus: 'healthy',
+    config: { urlSandbox: 'https://finkok.test', urlProduction: 'https://finkok.test', credentials: { username: 'user', password: 'pass' } }
+  });
+  manager.updateProviderConfig('ecodex', {
+    isActive: true,
+    healthStatus: 'healthy',
+    config: { urlSandbox: 'https://ecodex.test', urlProduction: 'https://ecodex.test', credentials: { username: 'user', password: 'pass' } }
+  });
+});
+
+afterEach(() => {
+  manager.destroy();
+  vi.restoreAllMocks();
+});
+
+describe('PAC integrations', () => {
+  test('timbrarFinkok success', async () => {
+    const xmlB64 = btoa(unescape(encodeURIComponent(sampleXml)));
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true,
+      text: async () => `<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\"><soap:Body><stampResponse xmlns=\"http://facturacion.finkok.com/stamp\"><stampResult><xml>${xmlB64}</xml><UUID>UUID123</UUID></stampResult></stampResponse></soap:Body></soap:Envelope>`
+    })) as any);
+
+    const result = await manager.timbrarConFailover(sampleXml, { ambiente: 'sandbox', maxRetries: 1, timeoutMs: 5000, preferredProvider: 'finkok' });
+    expect(result.success).toBe(true);
+    expect(result.uuid).toBe('UUID123');
+    expect(result.xmlTimbrado).toBe(sampleXml);
+    expect((fetch as any).mock.calls[0][1].body).toContain(xmlB64);
+  });
+
+  test('timbrarEcodex success', async () => {
+    const xmlB64 = btoa(unescape(encodeURIComponent(sampleXml)));
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true,
+      text: async () => `<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\"><soap:Body><TimbrarResponse><TimbrarResult><xml>${xmlB64}</xml><UUID>ECODEXUUID</UUID></TimbrarResult></TimbrarResponse></soap:Body></soap:Envelope>`
+    })) as any);
+
+    const result = await manager.timbrarConFailover(sampleXml, { ambiente: 'sandbox', maxRetries: 1, timeoutMs: 5000, preferredProvider: 'ecodex' });
+    expect(result.success).toBe(true);
+    expect(result.uuid).toBe('ECODEXUUID');
+    expect(result.xmlTimbrado).toBe(sampleXml);
+    expect((fetch as any).mock.calls[0][1].body).toContain(xmlB64);
+  });
+});


### PR DESCRIPTION
## Summary
- add Finkok and Ecodex integration methods with SOAP and timeouts
- update provider selection to pass timeout
- add tests simulating PAC responses

## Testing
- `bun install`
- `npx vitest run` *(fails: DOMMatrix is not defined and other hook tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_68531bcd95e0832b9dbbea2737a3fbe8