### PR TITLE
Set up lint/test workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+
+env:
+  NODE_ENV: test
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Lint
+        run: npm run lint
+      - name: Test
+        run: npx vitest run --coverage
+      - name: Upload coverage
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: coverage
+          if-no-files-found: warn


### PR DESCRIPTION
## Summary
- add CI workflow with lint and tests on Node 18

## Testing
- `npm install`
- `npm run lint` *(fails: 655 problems)*
- `npx vitest run --coverage` *(fails: multiple tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_68531bcf5784832bb1c976be7cc3dd5a