### PR TITLE
Add customs and distance fields

### DIFF
--- a/src/components/carta-porte/configuracion/ConfiguracionPrincipal.tsx
+++ b/src/components/carta-porte/configuracion/ConfiguracionPrincipal.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
+import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { ArrowRight } from 'lucide-react';
 import { DatosEmisor } from './DatosEmisor';
@@ -67,6 +68,31 @@ export function ConfiguracionPrincipal({
 
         {/* Opciones Especiales */}
         <OpcionesEspeciales data={data} onChange={onChange} />
+
+        {/* Datos adicionales */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div className="space-y-2">
+            <Label>Total Distancia Recorrida (km)</Label>
+            <Input
+              type="number"
+              value={data.totalDistRec ?? ''}
+              onChange={(e) =>
+                onChange({ totalDistRec: parseFloat(e.target.value) || 0 })
+              }
+              placeholder="0"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label>Régimen Aduanero</Label>
+            <Input
+              value={data.regimenAduanero || ''}
+              onChange={(e) =>
+                onChange({ regimenAduanero: e.target.value })
+              }
+              placeholder="Régimen Aduanero"
+            />
+          </div>
+        </div>
 
         <div className="flex justify-end">
           <Button 

--- a/src/components/carta-porte/configuracion/ConfiguracionPrincipalMejorada.tsx
+++ b/src/components/carta-porte/configuracion/ConfiguracionPrincipalMejorada.tsx
@@ -5,6 +5,7 @@ import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { ClienteSelector } from '@/components/crm/ClienteSelector';
 import { ArrowRight } from 'lucide-react';
+import { Input } from '@/components/ui/input';
 import { OpcionesEspeciales } from './OpcionesEspeciales';
 import { CartaPorteData } from '@/types/cartaPorte';
 import { ClienteProveedor } from '@/hooks/crm/useClientesProveedores';
@@ -125,6 +126,31 @@ const ConfiguracionPrincipalMejoradaComponent = ({
         </div>
 
         <OpcionesEspeciales data={data} onChange={onChange} />
+
+        {/* Datos adicionales */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div className="space-y-2">
+            <Label>Total Distancia Recorrida (km)</Label>
+            <Input
+              type="number"
+              value={data.totalDistRec ?? ''}
+              onChange={(e) =>
+                onChange({ totalDistRec: parseFloat(e.target.value) || 0 })
+              }
+              placeholder="0"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label>Régimen Aduanero</Label>
+            <Input
+              value={data.regimenAduanero || ''}
+              onChange={(e) =>
+                onChange({ regimenAduanero: e.target.value })
+              }
+              placeholder="Régimen Aduanero"
+            />
+          </div>
+        </div>
 
         <div className="flex justify-end">
           <Button 

--- a/src/hooks/carta-porte/useCartaPorteValidationEnhanced.ts
+++ b/src/hooks/carta-porte/useCartaPorteValidationEnhanced.ts
@@ -78,10 +78,20 @@ export const useCartaPorteValidationEnhanced = ({
     
     const traditionalResult = validateTraditional(dataToValidate);
     const summary = getValidationSummary(dataToValidate);
+
+    // Campos adicionales requeridos para generación de XML
+    const extraFieldsValid =
+      dataToValidate.totalDistRec !== undefined &&
+      dataToValidate.totalDistRec > 0 &&
+      !!(dataToValidate.regimenAduanero ||
+        (dataToValidate.regimenesAduaneros && dataToValidate.regimenesAduaneros.length > 0));
+
+    const baseValid = traditionalResult.isValid && extraFieldsValid;
     
     if (!enableAI) {
       return {
         ...traditionalResult,
+        isValid: baseValid,
         completionPercentage: summary.completionPercentage,
         aiEnhancements: null,
         overallScore: summary.completionPercentage,
@@ -99,6 +109,7 @@ export const useCartaPorteValidationEnhanced = ({
 
       return {
         ...traditionalResult,
+        isValid: baseValid,
         completionPercentage: summary.completionPercentage,
         aiEnhancements: {
           suggestions: aiResult.aiSuggestions || [],
@@ -113,6 +124,7 @@ export const useCartaPorteValidationEnhanced = ({
       console.error('Error in AI validation:', error);
       return {
         ...traditionalResult,
+        isValid: baseValid,
         completionPercentage: summary.completionPercentage,
         aiEnhancements: null,
         overallScore: summary.completionPercentage,

--- a/src/services/xml/xmlComplemento.ts
+++ b/src/services/xml/xmlComplemento.ts
@@ -10,12 +10,14 @@ export class XMLComplementoBuilder {
   }
 
   private static construirCartaPorte(data: CartaPorteData): string {
-    const distanciaTotal = XMLUtils.calcularDistanciaTotal(data.ubicaciones || []);
+    const distanciaTotal =
+      data.totalDistRec ?? XMLUtils.calcularDistanciaTotal(data.ubicaciones || []);
     
     return `<cartaporte31:CartaPorte 
       Version="3.1" 
       TranspInternac="${data.transporteInternacional ? 'Sí' : 'No'}"
       ${data.transporteInternacional ? XMLUtils.construirAtributosInternacionales(data) : ''}
+      ${data.regimenAduanero ? `RegimenAduanero="${data.regimenAduanero}"` : ''}
       TotalDistRec="${distanciaTotal}">
       
       ${this.construirUbicaciones(data.ubicaciones || [])}

--- a/src/services/xml/xmlUtils.ts
+++ b/src/services/xml/xmlUtils.ts
@@ -31,7 +31,8 @@ export class XMLUtils {
     return (
       `EntradaSalidaMerc="${data.entradaSalidaMerc ?? ''}" ` +
       `PaisOrigenDestino="${data.pais_origen_destino ?? ''}" ` +
-      `ViaEntradaSalida="${data.via_entrada_salida ?? ''}" `
+      `ViaEntradaSalida="${data.via_entrada_salida ?? ''}" ` +
+      (data.regimenAduanero ? `RegimenAduanero="${data.regimenAduanero}" ` : '')
     );
   }
 
@@ -61,5 +62,6 @@ export const buildComplementoCartaPorte = (data: any): string => {
     Version="3.1"
     TranspInternac="${data.transporteInternacional ? 'Sí' : 'No'}"
     ${XMLUtils.construirAtributosInternacionales(data)}
+    ${data.regimenAduanero ? `RegimenAduanero="${data.regimenAduanero}"` : ''}
     TotalDistRec="${data.totalDistRec ?? 0}" />`;
 };


### PR DESCRIPTION
## Summary
- allow capturing total distance and customs regime in configuration
- require these fields to validate full Carta Porte form
- include RegimenAduanero and user-provided distance in XML

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685330ccdc1c832baf6eabe0db76e194