### PR TITLE
Use server PDF in PDFGenerationPanel

### DIFF
--- a/src/components/carta-porte/xml/PDFGenerationPanel.tsx
+++ b/src/components/carta-porte/xml/PDFGenerationPanel.tsx
@@ -6,8 +6,7 @@ import { Badge } from '@/components/ui/badge';
 import { FileText, Download, Eye, Loader2, CheckCircle } from 'lucide-react';
 import { CartaPorteData } from '@/types/cartaPorte';
 import { toast } from 'sonner';
-import jsPDF from 'jspdf';
-import 'jspdf-autotable';
+import { CartaPortePDFService } from '@/services/CartaPortePDFService';
 
 interface PDFGenerationPanelProps {
   cartaPorteData: CartaPorteData;
@@ -22,151 +21,27 @@ export function PDFGenerationPanel({
 }: PDFGenerationPanelProps) {
   const [isGenerating, setIsGenerating] = useState(false);
   const [pdfUrl, setPdfUrl] = useState<string | null>(null);
-  const [showPreview, setShowPreview] = useState(false);
 
   const generatePDF = async () => {
     if (isGenerating) return;
-    
+
+    const cartaPorteId = cartaPorteData.cartaPorteId;
+    if (!cartaPorteId) {
+      toast.error('ID de Carta Porte requerido para generar el PDF');
+      return;
+    }
+
     setIsGenerating(true);
     try {
-      console.log('📄 Generando PDF de carta porte...');
-      
-      const pdf = new jsPDF();
-      const pageWidth = pdf.internal.pageSize.width;
-      let yPosition = 20;
+      const result = await CartaPortePDFService.generate(cartaPorteId);
 
-      // Función helper para agregar texto
-      const addText = (text: string, x: number = 20, fontSize: number = 12, style: 'normal' | 'bold' = 'normal') => {
-        pdf.setFontSize(fontSize);
-        pdf.setFont('helvetica', style);
-        pdf.text(text, x, yPosition);
-        yPosition += fontSize * 0.5 + 2;
-      };
-
-      // Función helper para agregar separador
-      const addSeparator = () => {
-        yPosition += 5;
-        pdf.setDrawColor(200, 200, 200);
-        pdf.line(20, yPosition, pageWidth - 20, yPosition);
-        yPosition += 10;
-      };
-
-      // Encabezado
-      addText('CARTA PORTE - COMPLEMENTO CFDI', 20, 18, 'bold');
-      const folio = cartaPorteData.folio || `CP-${Date.now().toString().slice(-8)}`;
-      addText(`Folio: ${folio}`, 20, 12);
-      addText(`Fecha: ${new Date().toLocaleDateString('es-MX')}`, 20, 12);
-      addSeparator();
-
-      // Información del CFDI
-      addText('INFORMACIÓN DEL CFDI', 20, 14, 'bold');
-      addText(`Tipo de CFDI: ${cartaPorteData.tipoCfdi || 'Traslado'}`, 25, 11);
-      addText(`Versión Carta Porte: ${cartaPorteData.cartaPorteVersion || '3.1'}`, 25, 11);
-      addText(`Transporte Internacional: ${cartaPorteData.transporteInternacional === true || cartaPorteData.transporteInternacional === 'Sí' ? 'Sí' : 'No'}`, 25, 11);
-      addSeparator();
-
-      // Emisor y Receptor
-      addText('EMISOR', 20, 14, 'bold');
-      addText(`RFC: ${cartaPorteData.rfcEmisor || 'No especificado'}`, 25, 11);
-      addText(`Nombre: ${cartaPorteData.nombreEmisor || 'No especificado'}`, 25, 11);
-      yPosition += 5;
-
-      addText('RECEPTOR', 20, 14, 'bold');
-      addText(`RFC: ${cartaPorteData.rfcReceptor || 'No especificado'}`, 25, 11);
-      addText(`Nombre: ${cartaPorteData.nombreReceptor || 'No especificado'}`, 25, 11);
-      addSeparator();
-
-      // Ubicaciones
-      if (cartaPorteData.ubicaciones && cartaPorteData.ubicaciones.length > 0) {
-        addText('UBICACIONES', 20, 14, 'bold');
-        cartaPorteData.ubicaciones.forEach((ubicacion, index) => {
-          addText(`${index + 1}. ${ubicacion.tipo_ubicacion}: ${ubicacion.id_ubicacion}`, 25, 11);
-          if (ubicacion.domicilio) {
-            addText(`   ${ubicacion.domicilio.calle} ${ubicacion.domicilio.numero_exterior}`, 30, 10);
-            addText(`   ${ubicacion.domicilio.colonia}, ${ubicacion.domicilio.municipio}`, 30, 10);
-            addText(`   CP: ${ubicacion.domicilio.codigo_postal}, ${ubicacion.domicilio.estado}`, 30, 10);
-          }
-          if (ubicacion.rfc_remitente_destinatario) {
-            addText(`   RFC: ${ubicacion.rfc_remitente_destinatario}`, 30, 10);
-          }
-          if (ubicacion.nombre_remitente_destinatario) {
-            addText(`   Nombre: ${ubicacion.nombre_remitente_destinatario}`, 30, 10);
-          }
-          yPosition += 3;
-        });
-        addSeparator();
+      if (result.success && result.pdfUrl) {
+        setPdfUrl(result.pdfUrl);
+        onPDFGenerated?.(result.pdfUrl);
+        toast.success('PDF generado correctamente');
+      } else {
+        throw new Error(result.error || 'PDF no generado');
       }
-
-      // Mercancías
-      if (cartaPorteData.mercancias && cartaPorteData.mercancias.length > 0) {
-        addText('MERCANCÍAS', 20, 14, 'bold');
-        cartaPorteData.mercancias.forEach((mercancia, index) => {
-          addText(`${index + 1}. ${mercancia.bienes_transp}`, 25, 11);
-          if (mercancia.descripcion) {
-            addText(`   Descripción: ${mercancia.descripcion}`, 30, 10);
-          }
-          if (mercancia.cantidad) {
-            addText(`   Cantidad: ${mercancia.cantidad} ${mercancia.clave_unidad || ''}`, 30, 10);
-          }
-          if (mercancia.peso_kg) {
-            addText(`   Peso: ${mercancia.peso_kg} kg`, 30, 10);
-          }
-          if (mercancia.valor_mercancia) {
-            addText(`   Valor: $${mercancia.valor_mercancia} ${mercancia.moneda || 'MXN'}`, 30, 10);
-          }
-          yPosition += 3;
-        });
-        addSeparator();
-      }
-
-      // Autotransporte
-      if (cartaPorteData.autotransporte) {
-        addText('AUTOTRANSPORTE', 20, 14, 'bold');
-        const auto = cartaPorteData.autotransporte;
-        if (auto.placa_vm) addText(`Placa: ${auto.placa_vm}`, 25, 11);
-        if (auto.config_vehicular) addText(`Configuración: ${auto.config_vehicular}`, 25, 11);
-        if (auto.anio_modelo_vm) addText(`Año: ${auto.anio_modelo_vm}`, 25, 11);
-        if (auto.perm_sct) addText(`Permiso SCT: ${auto.perm_sct}`, 25, 11);
-        if (auto.num_permiso_sct) addText(`Núm. Permiso: ${auto.num_permiso_sct}`, 25, 11);
-        if (auto.asegura_resp_civil) addText(`Aseguradora: ${auto.asegura_resp_civil}`, 25, 11);
-        if (auto.poliza_resp_civil) addText(`Póliza: ${auto.poliza_resp_civil}`, 25, 11);
-        addSeparator();
-      }
-
-      // Figuras de Transporte
-      if (cartaPorteData.figuras && cartaPorteData.figuras.length > 0) {
-        addText('FIGURAS DE TRANSPORTE', 20, 14, 'bold');
-        cartaPorteData.figuras.forEach((figura, index) => {
-          addText(`${index + 1}. ${figura.tipo_figura}`, 25, 11);
-          addText(`   RFC: ${figura.rfc_figura}`, 30, 10);
-          addText(`   Nombre: ${figura.nombre_figura}`, 30, 10);
-          if (figura.num_licencia) {
-            addText(`   Licencia: ${figura.num_licencia}`, 30, 10);
-          }
-          yPosition += 3;
-        });
-        addSeparator();
-      }
-
-      // Información de XML si existe
-      if (xmlGenerado) {
-        addText('ESTADO DEL XML', 20, 14, 'bold');
-        addText('✓ XML generado correctamente', 25, 11);
-        addText(`Generado: ${new Date().toLocaleString('es-MX')}`, 25, 11);
-      }
-
-      // Generar URL del PDF
-      const pdfBlob = pdf.output('blob');
-      const url = URL.createObjectURL(pdfBlob);
-      setPdfUrl(url);
-      
-      if (onPDFGenerated) {
-        onPDFGenerated(url);
-      }
-
-      console.log('✅ PDF generado exitosamente');
-      toast.success('PDF generado correctamente');
-      
     } catch (error) {
       console.error('❌ Error generando PDF:', error);
       toast.error('Error al generar el PDF');


### PR DESCRIPTION
## Summary
- switch PDFGenerationPanel to use `CartaPortePDFService.generate`
- fetch and download the server PDF instead of generating client-side

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685331116d54832bbbfff860ed81afe7