### PR TITLE
Add auth check to saldo PAC function

### DIFF
--- a/supabase/functions/consultar-saldo-pac/index.ts
+++ b/supabase/functions/consultar-saldo-pac/index.ts
@@ -1,14 +1,28 @@
 
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
-
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
+import { verifyAuth, logSecurityEvent, corsHeaders } from "../_shared/auth.ts";
 
 const handler = async (req: Request): Promise<Response> => {
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });
+  }
+
+  const { error: authError, user } = await verifyAuth(req);
+  if (authError || !user) {
+    await logSecurityEvent(
+      user?.id ?? 'anonymous',
+      'unauthorized_access',
+      { endpoint: 'consultar-saldo-pac' },
+      req.headers.get('x-forwarded-for') ?? undefined,
+      req.headers.get('user-agent') ?? undefined,
+    );
+    return (
+      authError ??
+      new Response(JSON.stringify({ error: 'Unauthorized' }), {
+        status: 401,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      })
+    );
   }
 
   try {


### PR DESCRIPTION
## Summary
- validate Bearer token in consultar-saldo-pac function
- log security events for unauthorized requests

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68533112c1e0832b9dab7690bc11cf63