### PR TITLE
Implement Carta Porte 3.1 updates

### DIFF
--- a/src/services/xml/xmlComplemento.ts
+++ b/src/services/xml/xmlComplemento.ts
@@ -13,18 +13,23 @@ export class XMLComplementoBuilder {
     const distanciaTotal =
       data.totalDistRec ?? XMLUtils.calcularDistanciaTotal(data.ubicaciones || []);
     
-    return `<cartaporte31:CartaPorte 
-      Version="3.1" 
+    const id = data.idCCP || XMLUtils.generarIdCCP();
+    data.idCCP = id;
+    const regimenes = XMLUtils.construirRegimenesAduaneros(data);
+
+    return `<cartaporte31:CartaPorte
+      Version="3.1"
       TranspInternac="${data.transporteInternacional ? 'Sí' : 'No'}"
+      IdCCP="${id}"
       ${data.transporteInternacional ? XMLUtils.construirAtributosInternacionales(data) : ''}
-      ${data.regimenAduanero ? `RegimenAduanero="${data.regimenAduanero}"` : ''}
       TotalDistRec="${distanciaTotal}">
-      
+
+      ${regimenes}
       ${this.construirUbicaciones(data.ubicaciones || [])}
       ${this.construirMercancias(data.mercancias || [])}
       ${this.construirFiguraTransporte(data.figuras || [])}
       ${this.construirAutotransporte(data.autotransporte)}
-      
+
     </cartaporte31:CartaPorte>`;
   }
 
@@ -82,6 +87,7 @@ export class XMLComplementoBuilder {
         ${mercancia.moneda ? `Moneda="${mercancia.moneda}"` : ''}
         ${mercancia.material_peligroso ? `MaterialPeligroso="Sí"` : ''}
         ${mercancia.cve_material_peligroso ? `CveMaterialPeligroso="${mercancia.cve_material_peligroso}"` : ''}
+        ${mercancia.fraccion_arancelaria ? `FraccionArancelaria="${mercancia.fraccion_arancelaria}"` : ''}
         ${mercancia.embalaje ? `Embalaje="${mercancia.embalaje}"` : ''} />`;
     }).join('\n      ');
 
@@ -140,7 +146,8 @@ export class XMLComplementoBuilder {
       <cartaporte31:IdentificacionVehicular
         ConfigVehicular="${autotransporte.config_vehicular || ''}"
         PlacaVM="${autotransporte.placa_vm || ''}"
-        AnioModeloVM="${autotransporte.anio_modelo_vm || ''}" />
+        AnioModeloVM="${autotransporte.anio_modelo_vm || ''}"
+        ${autotransporte.peso_bruto_vehicular ? `PesoBrutoVehicular="${autotransporte.peso_bruto_vehicular}"` : ''} />
         
       ${this.construirSeguros(autotransporte)}
       ${this.construirRemolques(autotransporte.remolques)}

--- a/src/types/cartaPorte.ts
+++ b/src/types/cartaPorte.ts
@@ -21,6 +21,7 @@ export interface CartaPorteData {
   pais_origen_destino?: string;
   via_entrada_salida?: string;
   folio?: string;
+  idCCP?: string;
   cartaPorteId?: string;
   
   // Campos para persistencia de estado

--- a/supabase/functions/generar-pdf-carta-porte/index.ts
+++ b/supabase/functions/generar-pdf-carta-porte/index.ts
@@ -49,6 +49,7 @@ serve(async (req) => {
     const cadenaOriginal = meta.cadena_original ?? '';
     const selloDigital = meta.sello_digital ?? '';
     let qrCode: string | undefined = meta.qrCode || meta.qr_code;
+    let idCCP: string | undefined = meta.idCCP;
 
     let formData: any = {};
     try {
@@ -59,9 +60,15 @@ serve(async (req) => {
       formData = {};
     }
 
-    if (!qrCode && data.xml_generado) {
-      const match = data.xml_generado.match(/QRCode="([^"]+)"/);
-      if (match) qrCode = match[1];
+    if (data.xml_generado) {
+      if (!qrCode) {
+        const matchQR = data.xml_generado.match(/QRCode="([^"]+)"/);
+        if (matchQR) qrCode = matchQR[1];
+      }
+      if (!idCCP) {
+        const matchId = data.xml_generado.match(/IdCCP="([^"]+)"/);
+        if (matchId) idCCP = matchId[1];
+      }
     }
 
     const pdfDoc = await PDFDocument.create();
@@ -83,6 +90,7 @@ serve(async (req) => {
 
     drawText('Carta Porte', { bold: true, size: 18 });
     if (data.uuid_fiscal) drawText(`UUID: ${data.uuid_fiscal}`);
+    if (idCCP) drawText(`IdCCP: ${idCCP}`);
     if (selloDigital) drawText(`Sello Digital: ${selloDigital}`, { size: 8 });
     if (cadenaOriginal) drawText(`Cadena Original: ${cadenaOriginal}`, { size: 8 });
     y -= 10;
@@ -142,6 +150,7 @@ serve(async (req) => {
         success: true,
         pdfBase64,
         uuid: data.uuid_fiscal,
+        idCCP,
         selloDigital,
         cadenaOriginal,
         qrCode,


### PR DESCRIPTION
## Summary
- generate IdCCP identifiers when building Carta Porte XML
- support RegimenesAduaneros node
- include PesoBrutoVehicular in vehicle data
- expose IdCCP in generated PDFs

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685344f3c714832bb17c612bf6c95157