### PR TITLE
Remove distance field from config and auto-update total distance

### DIFF
--- a/src/components/carta-porte/configuracion/ConfiguracionPrincipal.tsx
+++ b/src/components/carta-porte/configuracion/ConfiguracionPrincipal.tsx
@@ -70,28 +70,15 @@ export function ConfiguracionPrincipal({
         <OpcionesEspeciales data={data} onChange={onChange} />
 
         {/* Datos adicionales */}
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div className="space-y-2">
-            <Label>Total Distancia Recorrida (km)</Label>
-            <Input
-              type="number"
-              value={data.totalDistRec ?? ''}
-              onChange={(e) =>
-                onChange({ totalDistRec: parseFloat(e.target.value) || 0 })
-              }
-              placeholder="0"
-            />
-          </div>
-          <div className="space-y-2">
-            <Label>Régimen Aduanero</Label>
-            <Input
-              value={data.regimenAduanero || ''}
-              onChange={(e) =>
-                onChange({ regimenAduanero: e.target.value })
-              }
-              placeholder="Régimen Aduanero"
-            />
-          </div>
+        <div className="space-y-2">
+          <Label>Régimen Aduanero</Label>
+          <Input
+            value={data.regimenAduanero || ''}
+            onChange={(e) =>
+              onChange({ regimenAduanero: e.target.value })
+            }
+            placeholder="Régimen Aduanero"
+          />
         </div>
 
         <div className="flex justify-end">

--- a/src/components/carta-porte/configuracion/ConfiguracionPrincipalMejorada.tsx
+++ b/src/components/carta-porte/configuracion/ConfiguracionPrincipalMejorada.tsx
@@ -128,28 +128,15 @@ const ConfiguracionPrincipalMejoradaComponent = ({
         <OpcionesEspeciales data={data} onChange={onChange} />
 
         {/* Datos adicionales */}
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div className="space-y-2">
-            <Label>Total Distancia Recorrida (km)</Label>
-            <Input
-              type="number"
-              value={data.totalDistRec ?? ''}
-              onChange={(e) =>
-                onChange({ totalDistRec: parseFloat(e.target.value) || 0 })
-              }
-              placeholder="0"
-            />
-          </div>
-          <div className="space-y-2">
-            <Label>Régimen Aduanero</Label>
-            <Input
-              value={data.regimenAduanero || ''}
-              onChange={(e) =>
-                onChange({ regimenAduanero: e.target.value })
-              }
-              placeholder="Régimen Aduanero"
-            />
-          </div>
+        <div className="space-y-2">
+          <Label>Régimen Aduanero</Label>
+          <Input
+            value={data.regimenAduanero || ''}
+            onChange={(e) =>
+              onChange({ regimenAduanero: e.target.value })
+            }
+            placeholder="Régimen Aduanero"
+          />
         </div>
 
         <div className="flex justify-end">

--- a/src/hooks/carta-porte/useCartaPorteFormManager.ts
+++ b/src/hooks/carta-porte/useCartaPorteFormManager.ts
@@ -222,7 +222,8 @@ export function useCartaPorteFormManager(cartaPorteId?: string) {
     // Actualizar estado local
     setFormData(prev => ({
       ...prev,
-      datosCalculoRuta: newDatosRuta
+      datosCalculoRuta: newDatosRuta,
+      totalDistRec: datos.distanciaTotal ?? prev.totalDistRec
     }));
     
     // Auto-guardar cuando se actualiza cálculo de ruta


### PR DESCRIPTION
## Summary
- remove `Total Distancia Recorrida` input from configuration forms
- update form manager to save `totalDistRec` when route distance is calculated

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685368a66c60832b94417587a3109674