### PR TITLE
Add regimenes aduaneros array support

### DIFF
--- a/src/components/carta-porte/configuracion/ConfiguracionPrincipal.tsx
+++ b/src/components/carta-porte/configuracion/ConfiguracionPrincipal.tsx
@@ -9,6 +9,7 @@ import { ArrowRight } from 'lucide-react';
 import { DatosEmisor } from './DatosEmisor';
 import { DatosReceptor } from './DatosReceptor';
 import { OpcionesEspeciales } from './OpcionesEspeciales';
+import { RegimenesAduanerosList } from './RegimenesAduanerosList';
 import { CartaPorteData } from '../CartaPorteForm';
 
 interface ConfiguracionPrincipalProps {
@@ -18,17 +19,21 @@ interface ConfiguracionPrincipalProps {
   isFormValid: boolean;
 }
 
-export function ConfiguracionPrincipal({ 
-  data, 
-  onChange, 
-  onNext, 
-  isFormValid 
+export function ConfiguracionPrincipal({
+  data,
+  onChange,
+  onNext,
+  isFormValid
 }: ConfiguracionPrincipalProps) {
   const handleTipoCfdiChange = (value: string) => {
     if (value === 'Ingreso' || value === 'Traslado') {
       onChange({ tipoCfdi: value });
     }
   };
+
+  const isTransporteInternacional =
+    data.transporteInternacional === 'Sí' || data.transporteInternacional === true;
+  const isVersion31 = data.cartaPorteVersion === '3.1';
 
   return (
     <Card>
@@ -70,16 +75,23 @@ export function ConfiguracionPrincipal({
         <OpcionesEspeciales data={data} onChange={onChange} />
 
         {/* Datos adicionales */}
-        <div className="space-y-2">
-          <Label>Régimen Aduanero</Label>
-          <Input
-            value={data.regimenAduanero || ''}
-            onChange={(e) =>
-              onChange({ regimenAduanero: e.target.value })
-            }
-            placeholder="Régimen Aduanero"
+        {!isTransporteInternacional && (
+          <div className="space-y-2">
+            <Label>Régimen Aduanero</Label>
+            <Input
+              value={data.regimenAduanero || ''}
+              onChange={(e) => onChange({ regimenAduanero: e.target.value })}
+              placeholder="Régimen Aduanero"
+            />
+          </div>
+        )}
+
+        {isVersion31 && isTransporteInternacional && (
+          <RegimenesAduanerosList
+            regimenes={data.regimenesAduaneros || []}
+            onChange={(regs) => onChange({ regimenesAduaneros: regs })}
           />
-        </div>
+        )}
 
         <div className="flex justify-end">
           <Button 

--- a/src/components/carta-porte/configuracion/ConfiguracionPrincipalMejorada.tsx
+++ b/src/components/carta-porte/configuracion/ConfiguracionPrincipalMejorada.tsx
@@ -9,6 +9,7 @@ import { Input } from '@/components/ui/input';
 import { OpcionesEspeciales } from './OpcionesEspeciales';
 import { CartaPorteData } from '@/types/cartaPorte';
 import { ClienteProveedor } from '@/hooks/crm/useClientesProveedores';
+import { RegimenesAduanerosList } from './RegimenesAduanerosList';
 
 interface ConfiguracionPrincipalMejoradaProps {
   data: CartaPorteData;
@@ -71,6 +72,10 @@ const ConfiguracionPrincipalMejoradaComponent = ({
     });
   };
 
+  const isTransporteInternacional =
+    data.transporteInternacional === 'Sí' || data.transporteInternacional === true;
+  const isVersion31 = data.cartaPorteVersion === '3.1';
+
   const isFormCompleto = () => {
     return !!(data.tipoCfdi && data.rfcEmisor && data.nombreEmisor && data.rfcReceptor && data.nombreReceptor);
   };
@@ -128,16 +133,23 @@ const ConfiguracionPrincipalMejoradaComponent = ({
         <OpcionesEspeciales data={data} onChange={onChange} />
 
         {/* Datos adicionales */}
-        <div className="space-y-2">
-          <Label>Régimen Aduanero</Label>
-          <Input
-            value={data.regimenAduanero || ''}
-            onChange={(e) =>
-              onChange({ regimenAduanero: e.target.value })
-            }
-            placeholder="Régimen Aduanero"
+        {!isTransporteInternacional && (
+          <div className="space-y-2">
+            <Label>Régimen Aduanero</Label>
+            <Input
+              value={data.regimenAduanero || ''}
+              onChange={(e) => onChange({ regimenAduanero: e.target.value })}
+              placeholder="Régimen Aduanero"
+            />
+          </div>
+        )}
+
+        {isVersion31 && isTransporteInternacional && (
+          <RegimenesAduanerosList
+            regimenes={data.regimenesAduaneros || []}
+            onChange={(regs) => onChange({ regimenesAduaneros: regs })}
           />
-        </div>
+        )}
 
         <div className="flex justify-end">
           <Button 

--- a/src/components/carta-porte/configuracion/RegimenesAduanerosList.tsx
+++ b/src/components/carta-porte/configuracion/RegimenesAduanerosList.tsx
@@ -1,0 +1,65 @@
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { CatalogoSelectorMejorado } from '@/components/catalogos/CatalogoSelectorMejorado';
+import { Plus, Trash2 } from 'lucide-react';
+
+interface RegimenesAduanerosListProps {
+  regimenes: string[];
+  onChange: (regs: string[]) => void;
+}
+
+export function RegimenesAduanerosList({ regimenes, onChange }: RegimenesAduanerosListProps) {
+  const addRegimen = () => {
+    if (regimenes.length >= 10) return;
+    onChange([...regimenes, '']);
+  };
+
+  const updateRegimen = (index: number, value: string) => {
+    const updated = regimenes.map((r, i) => (i === index ? value : r));
+    onChange(updated);
+  };
+
+  const removeRegimen = (index: number) => {
+    onChange(regimenes.filter((_, i) => i !== index));
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h4 className="font-medium">Regímenes Aduaneros</h4>
+        <Button type="button" variant="outline" size="sm" onClick={addRegimen} disabled={regimenes.length >= 10}>
+          <Plus className="h-4 w-4 mr-2" /> Agregar Régimen Aduanero
+        </Button>
+      </div>
+
+      {regimenes.length === 0 ? (
+        <Card>
+          <CardContent className="py-4 text-center text-muted-foreground">
+            No hay régimenes aduaneros agregados
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="space-y-4">
+          {regimenes.map((regimen, index) => (
+            <Card key={index}>
+              <CardHeader className="flex items-center justify-between p-4">
+                <CardTitle className="text-base">Régimen {index + 1}</CardTitle>
+                <Button type="button" variant="destructive" size="sm" onClick={() => removeRegimen(index)}>
+                  <Trash2 className="h-4 w-4" />
+                </Button>
+              </CardHeader>
+              <CardContent className="space-y-2">
+                <CatalogoSelectorMejorado
+                  tipo="regimenes_aduaneros"
+                  value={regimen}
+                  onValueChange={(val) => updateRegimen(index, val)}
+                  placeholder="Selecciona régimen..."
+                />
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/catalogos/CatalogoSelectorMejorado.tsx
+++ b/src/components/catalogos/CatalogoSelectorMejorado.tsx
@@ -17,7 +17,17 @@ interface CatalogItem {
 }
 
 interface CatalogoSelectorMejoradoProps {
-  tipo: 'unidades' | 'productos' | 'embalajes' | 'materiales_peligrosos' | 'figuras_transporte' | 'tipos_permiso' | 'configuraciones_vehiculares' | 'remolques' | 'estados';
+  tipo:
+    | 'unidades'
+    | 'productos'
+    | 'embalajes'
+    | 'materiales_peligrosos'
+    | 'figuras_transporte'
+    | 'tipos_permiso'
+    | 'configuraciones_vehiculares'
+    | 'remolques'
+    | 'estados'
+    | 'regimenes_aduaneros';
   value?: string;
   onChange?: (value: string) => void;
   onValueChange?: (value: string) => void;

--- a/src/data/catalogosSATEstaticos.ts
+++ b/src/data/catalogosSATEstaticos.ts
@@ -113,6 +113,15 @@ export const UNIDADES_MEDIDA_SAT: CatalogoSATItem[] = [
   { clave: "HUR", descripcion: "Hora" }
 ];
 
+// Catálogo de Regímenes Aduaneros (simplificado)
+export const REGIMENES_ADUANEROS_SAT: CatalogoSATItem[] = [
+  { clave: 'A1', descripcion: 'Importación definitiva' },
+  { clave: 'A3', descripcion: 'Importación temporal' },
+  { clave: 'B1', descripcion: 'Exportación definitiva' },
+  { clave: 'B2', descripcion: 'Exportación temporal' },
+  { clave: 'C1', descripcion: 'Transformación o elaboración en recinto fiscalizado' }
+];
+
 // Función helper para formatear items del catálogo
 export const formatCatalogItem = (item: CatalogoSATItem) => ({
   value: item.clave,
@@ -130,6 +139,8 @@ export const getCatalogoEstatico = (tipo: string) => {
       return TIPOS_EMBALAJE_SAT.map(formatCatalogItem);
     case 'unidades':
       return UNIDADES_MEDIDA_SAT.map(formatCatalogItem);
+    case 'regimenes_aduaneros':
+      return REGIMENES_ADUANEROS_SAT.map(formatCatalogItem);
     default:
       return [];
   }

--- a/src/hooks/useCatalogosHibrido.ts
+++ b/src/hooks/useCatalogosHibrido.ts
@@ -39,6 +39,8 @@ export function useCatalogosHibrido(tipo: string, searchTerm: string = '', enabl
             return await CatalogosSATService.obtenerSubtiposRemolque(searchTerm);
           case 'estados':
             return await CatalogosSATService.obtenerEstados(searchTerm);
+          case 'regimenes_aduaneros':
+            return await CatalogosSATService.obtenerRegimenesAduaneros();
           default:
             return [];
         }

--- a/src/services/catalogosSAT.ts
+++ b/src/services/catalogosSAT.ts
@@ -432,4 +432,37 @@ export class CatalogosSATService {
       return [];
     }
   }
+
+  // Obtener regímenes aduaneros
+  static async obtenerRegimenesAduaneros(): Promise<CatalogoItem[]> {
+    const cacheKey = this.getCacheKey('regimenes_aduaneros');
+    const cached = cache.get(cacheKey);
+
+    if (cached && this.isCacheValid(cached.timestamp)) {
+      return cached.data;
+    }
+
+    try {
+      const { data, error } = await supabase
+        .from('cat_regimen_aduanero')
+        .select('clave_regimen, descripcion')
+        .order('clave_regimen');
+
+      if (error) {
+        console.error('Error fetching regimenes aduaneros:', error);
+        return [];
+      }
+
+      const result = (data || []).map(item => ({
+        clave: item.clave_regimen,
+        descripcion: item.descripcion
+      }));
+
+      cache.set(cacheKey, { data: result, timestamp: Date.now() });
+      return result;
+    } catch (error) {
+      console.error('Error in obtenerRegimenesAduaneros:', error);
+      return [];
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- switch to RegimenesAduanerosList when transporteInternacional is true
- allow selecting up to 10 entries from c_RegimenAduanero
- load static regimenes catalog and expose through hooks and selector
- add supabase service method for regimenes aduaneros

## Testing
- `npm run lint`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_685369c164ac832b9f2c63a844c0685c