### PR TITLE
Enforce distance for Destino and Paso Intermedio

### DIFF
--- a/src/components/carta-porte/ubicaciones/UbicacionDomicilioFormOptimizado.tsx
+++ b/src/components/carta-porte/ubicaciones/UbicacionDomicilioFormOptimizado.tsx
@@ -50,7 +50,10 @@ export function UbicacionDomicilioFormOptimizado({
         domicilio={domicilioUnificado}
         onDomicilioChange={handleDomicilioChange}
         onDireccionCompleta={handleDireccionCompleta}
-        mostrarDistancia={true}
+        mostrarDistancia={
+          formData.tipoUbicacion === 'Destino' ||
+          formData.tipoUbicacion === 'Paso Intermedio'
+        }
         distanciaRecorrida={formData.distanciaRecorrida}
         onDistanciaChange={handleDistanciaChange}
         camposOpcionales={['numInterior', 'referencia']}

--- a/src/components/carta-porte/ubicaciones/UbicacionFormOptimizado.tsx
+++ b/src/components/carta-porte/ubicaciones/UbicacionFormOptimizado.tsx
@@ -323,6 +323,14 @@ export function UbicacionFormOptimizado({
             <FormularioDomicilioUnificado
               domicilio={formData.domicilio}
               onDomicilioChange={handleDomicilioChange}
+              mostrarDistancia={
+                formData.tipoUbicacion === 'Destino' ||
+                formData.tipoUbicacion === 'Paso Intermedio'
+              }
+              distanciaRecorrida={formData.distanciaRecorrida}
+              onDistanciaChange={(dist) =>
+                setFormData(prev => ({ ...prev, distanciaRecorrida: dist }))
+              }
               camposOpcionales={['numInterior', 'referencia', 'localidad']}
             />
             

--- a/src/components/carta-porte/ubicaciones/UbicacionesSectionOptimizada.tsx
+++ b/src/components/carta-porte/ubicaciones/UbicacionesSectionOptimizada.tsx
@@ -131,9 +131,14 @@ export function UbicacionesSectionOptimizada({
         errores.push('La calle es requerida');
       }
 
-      if ((ubicacionData.tipoUbicacion === 'Origen' || ubicacionData.tipoUbicacion === 'Destino') && 
+      if ((ubicacionData.tipoUbicacion === 'Origen' || ubicacionData.tipoUbicacion === 'Destino') &&
           !ubicacionData.fechaHoraSalidaLlegada) {
         errores.push(`La fecha y hora ${ubicacionData.tipoUbicacion === 'Origen' ? 'de salida' : 'de llegada'} es requerida`);
+      }
+
+      if ((ubicacionData.tipoUbicacion === 'Destino' || ubicacionData.tipoUbicacion === 'Paso Intermedio') &&
+          (!ubicacionData.distanciaRecorrida || ubicacionData.distanciaRecorrida <= 0)) {
+        errores.push('La distancia recorrida es requerida');
       }
 
       if (errores.length > 0) {


### PR DESCRIPTION
## Summary
- show distance input in domicilio forms only for Destino and Paso Intermedio
- validate distanciaRecorrida when saving ubicaciones

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68536ba84700832b943c6c619f6858e5