### PR TITLE
Add peso_bruto_vehicular field

### DIFF
--- a/src/components/carta-porte/autotransporte/AutotransporteFormOptimizado.tsx
+++ b/src/components/carta-porte/autotransporte/AutotransporteFormOptimizado.tsx
@@ -55,6 +55,20 @@ export function AutotransporteFormOptimizado({ data, onChange }: AutotransporteF
                 placeholder="Ej: T2S1"
               />
             </div>
+
+            <div>
+              <Label htmlFor="peso_bruto_vehicular">Peso Bruto Vehicular (ton)</Label>
+              <Input
+                id="peso_bruto_vehicular"
+                type="number"
+                min="0"
+                step="0.01"
+                value={data.peso_bruto_vehicular ?? ''}
+                onChange={(e) =>
+                  handleFieldChange('peso_bruto_vehicular', parseFloat(e.target.value) || 0)
+                }
+              />
+            </div>
           </div>
         </CardContent>
       </Card>

--- a/src/components/carta-porte/autotransporte/VehiculoMotorForm.tsx
+++ b/src/components/carta-porte/autotransporte/VehiculoMotorForm.tsx
@@ -11,6 +11,7 @@ interface VehiculoMotorFormProps {
     placa_vm: string;
     anio_modelo_vm: number;
     config_vehicular: string;
+    peso_bruto_vehicular?: number;
   };
   onChange: (field: string, value: any) => void;
   errors: Record<string, string>;
@@ -62,6 +63,22 @@ export function VehiculoMotorForm({ data, onChange, errors }: VehiculoMotorFormP
             required
             error={errors.config_vehicular}
           />
+
+          <div>
+            <Label htmlFor="peso_bruto_vehicular">Peso Bruto Vehicular (ton)</Label>
+            <Input
+              id="peso_bruto_vehicular"
+              type="number"
+              min="0"
+              step="0.01"
+              value={data.peso_bruto_vehicular ?? ''}
+              onChange={(e) => onChange('peso_bruto_vehicular', parseFloat(e.target.value) || 0)}
+              className={errors.peso_bruto_vehicular ? 'border-red-500' : ''}
+            />
+            {errors.peso_bruto_vehicular && (
+              <p className="text-sm text-red-500 mt-1">{errors.peso_bruto_vehicular}</p>
+            )}
+          </div>
         </div>
       </CardContent>
     </Card>

--- a/src/components/carta-porte/autotransporte/VehiculoSection.tsx
+++ b/src/components/carta-porte/autotransporte/VehiculoSection.tsx
@@ -52,6 +52,18 @@ export function VehiculoSection({ data, onChange }: VehiculoSectionProps) {
           placeholder="Buscar configuración vehicular..."
           required
         />
+
+        <div className="space-y-2">
+          <Label htmlFor="peso_bruto_vehicular">Peso Bruto Vehicular (ton)</Label>
+          <Input
+            id="peso_bruto_vehicular"
+            type="number"
+            min="0"
+            step="0.01"
+            value={data.peso_bruto_vehicular ?? ''}
+            onChange={(e) => onChange('peso_bruto_vehicular', parseFloat(e.target.value) || 0)}
+          />
+        </div>
         
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <CatalogoSelectorMejorado

--- a/src/components/carta-porte/autotransporte/VehiculoSelector.tsx
+++ b/src/components/carta-porte/autotransporte/VehiculoSelector.tsx
@@ -43,7 +43,8 @@ export function VehiculoSelector({ data, onChange }: VehiculoSelectorProps) {
         asegura_resp_civil: vehiculo.asegura_resp_civil || '',
         poliza_resp_civil: vehiculo.poliza_resp_civil || vehiculo.poliza_seguro || '',
         asegura_med_ambiente: vehiculo.asegura_med_ambiente || '',
-        poliza_med_ambiente: vehiculo.poliza_med_ambiente || ''
+        poliza_med_ambiente: vehiculo.poliza_med_ambiente || '',
+        peso_bruto_vehicular: vehiculo.peso_bruto_vehicular || 0
       });
     }
   };

--- a/src/components/carta-porte/autotransporte/VehiculoSelectorSimplificado.tsx
+++ b/src/components/carta-porte/autotransporte/VehiculoSelectorSimplificado.tsx
@@ -44,7 +44,8 @@ export function VehiculoSelectorSimplificado({ data, onChange }: VehiculoSelecto
         asegura_resp_civil: vehiculo.asegura_resp_civil || '',
         poliza_resp_civil: vehiculo.poliza_resp_civil || vehiculo.poliza_seguro || '',
         asegura_med_ambiente: vehiculo.asegura_med_ambiente || '',
-        poliza_med_ambiente: vehiculo.poliza_med_ambiente || ''
+        poliza_med_ambiente: vehiculo.poliza_med_ambiente || '',
+        peso_bruto_vehicular: vehiculo.peso_bruto_vehicular || 0
       });
     }
   };
@@ -77,7 +78,8 @@ export function VehiculoSelectorSimplificado({ data, onChange }: VehiculoSelecto
                   asegura_resp_civil: '',
                   poliza_resp_civil: '',
                   asegura_med_ambiente: '',
-                  poliza_med_ambiente: ''
+                  poliza_med_ambiente: '',
+                  peso_bruto_vehicular: 0
                 });
               }}
             >

--- a/src/components/carta-porte/form/OptimizedCartaPorteForm.tsx
+++ b/src/components/carta-porte/form/OptimizedCartaPorteForm.tsx
@@ -57,6 +57,7 @@ const OptimizedCartaPorteForm = memo<OptimizedCartaPorteFormProps>(({ cartaPorte
     num_permiso_sct: '',
     asegura_resp_civil: '',
     poliza_resp_civil: '',
+    peso_bruto_vehicular: 0,
     remolques: []
   }), []);
 

--- a/src/hooks/carta-porte/useCartaPorteFormManager.ts
+++ b/src/hooks/carta-porte/useCartaPorteFormManager.ts
@@ -33,6 +33,7 @@ const initialCartaPorteData: CartaPorteData = {
     num_permiso_sct: '',
     asegura_resp_civil: '',
     poliza_resp_civil: '',
+    peso_bruto_vehicular: 0,
     remolques: []
   },
   figuras: [],
@@ -194,6 +195,7 @@ export function useCartaPorteFormManager(cartaPorteId?: string) {
     num_permiso_sct: '',
     asegura_resp_civil: '',
     poliza_resp_civil: '',
+    peso_bruto_vehicular: 0,
     remolques: []
   };
 

--- a/src/hooks/carta-porte/useCartaPorteValidation.ts
+++ b/src/hooks/carta-porte/useCartaPorteValidation.ts
@@ -128,6 +128,9 @@ export const useCartaPorteValidation = () => {
       if (!auto?.poliza_resp_civil) {
         missingFields.autotransporte.push('Póliza de seguro');
       }
+      if (!auto?.peso_bruto_vehicular) {
+        missingFields.autotransporte.push('Peso bruto vehicular');
+      }
       
       if (auto?.placa_vm) {
         autotransporteStatus = missingFields.autotransporte.length === 0 ? 'complete' : 'incomplete';

--- a/supabase/migrations/20250617120000-057a8fec-3e89-464e-b03e-767088395b89.sql
+++ b/supabase/migrations/20250617120000-057a8fec-3e89-464e-b03e-767088395b89.sql
@@ -1,0 +1,1 @@
+-- Add peso_bruto_vehicular to autotransporte\nALTER TABLE public.autotransporte ADD COLUMN IF NOT EXISTS peso_bruto_vehicular numeric;


### PR DESCRIPTION
## Summary
- add Peso Bruto Vehicular input to vehicle motor forms
- handle the new value in vehicle selectors
- require peso_bruto_vehicular during Carta Porte validation
- persist peso_bruto_vehicular in form defaults
- create migration for autotransporte table

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68536cbede50832bb369086218aef395