### PR TITLE
Enforce distance for destination locations

### DIFF
--- a/src/services/validation/SATValidation31Enhanced.ts
+++ b/src/services/validation/SATValidation31Enhanced.ts
@@ -162,7 +162,15 @@ export class SATValidation31Enhanced {
       }
       
       // Validar distancia recorrida
-      if (index > 0 && !ubicacion.distancia_recorrida) {
+      const requiereDistancia =
+        ubicacion.tipo_ubicacion === 'Destino' ||
+        ubicacion.tipo_ubicacion === 'Paso Intermedio';
+
+      if (requiereDistancia) {
+        if (!ubicacion.distancia_recorrida) {
+          errors.push(`${prefix}: Distancia recorrida es obligatoria`);
+        }
+      } else if (index > 0 && !ubicacion.distancia_recorrida) {
         warnings.push(`${prefix}: Se recomienda especificar distancia recorrida`);
       }
     }

--- a/src/tests/carta-porte/XMLValidation.test.tsx
+++ b/src/tests/carta-porte/XMLValidation.test.tsx
@@ -33,6 +33,7 @@ const mockValidCartaPorteData: CartaPorteData = {
       id: 'loc2',
       tipo_ubicacion: 'Destino',
       id_ubicacion: 'loc2',
+      distancia_recorrida: 100,
       domicilio: {
         pais: 'México',
         codigo_postal: '02000',


### PR DESCRIPTION
## Summary
- update validation to require `distancia_recorrida` for "Destino" and "Paso Intermedio" locations
- update XML validation tests to include this distance field

## Testing
- `npm run lint`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6853703c262c832b8e0c22f1722de481