### PR TITLE
Add SEMARNAT keyword detection

### DIFF
--- a/src/hooks/useMercancias.ts
+++ b/src/hooks/useMercancias.ts
@@ -17,6 +17,8 @@ export interface Mercancia {
   embalaje?: string;
   uuid_comercio_ext?: string;
   codigo_producto?: string;
+  numero_autorizacion?: string;
+  folio_acreditacion?: string;
 }
 
 export interface MercanciaConErrores extends Mercancia {

--- a/src/services/ai/GeminiCoreService.ts
+++ b/src/services/ai/GeminiCoreService.ts
@@ -232,6 +232,50 @@ export class GeminiCoreService {
     }
   }
 
+  async analyzeTextForRegulatedKeywords(
+    text: string,
+    context?: AIContextData
+  ): Promise<{ regulatedKeywords: string[]; hasRegulatedKeywords: boolean }> {
+    try {
+      const result = await this.callGeminiAPI(
+        'analyze_regulated_keywords',
+        { text },
+        context
+      );
+
+      return (
+        result || { regulatedKeywords: [], hasRegulatedKeywords: false }
+      );
+    } catch (error) {
+      console.error('[GeminiCore] Error analyzing text:', error);
+      return { regulatedKeywords: [], hasRegulatedKeywords: false };
+    }
+  }
+
+  async generateLegalDescription(
+    descripcion: string,
+    numeroAutorizacion: string,
+    folioAcreditacion: string,
+    context?: AIContextData
+  ): Promise<string> {
+    try {
+      const result = await this.callGeminiAPI(
+        'generate_legal_description',
+        {
+          descripcion,
+          numeroAutorizacion,
+          folioAcreditacion
+        },
+        context
+      );
+
+      return result?.descripcion || '';
+    } catch (error) {
+      console.error('[GeminiCore] Error generating legal description:', error);
+      return '';
+    }
+  }
+
   clearCache(): void {
     this.cache.clear();
   }


### PR DESCRIPTION
## Summary
- analyze mercancía description with `GeminiCoreService`
- show SEMARNAT fields when regulated keywords found
- generate legal description and lock original field
- extend `Mercancia` type

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853715d6af4832bb7f97d5b1b5150b4