### PR TITLE
Warn if cargo weight exceeds vehicle capacity

### DIFF
--- a/src/components/carta-porte/AutotransporteSection.tsx
+++ b/src/components/carta-porte/AutotransporteSection.tsx
@@ -5,16 +5,18 @@ import { AutotransporteSectionOptimizada } from './autotransporte/Autotransporte
 
 interface AutotransporteSectionProps {
   data: any;
+  pesoTotalMercancias: number;
   onChange: (data: any) => void;
   onNext: () => void;
   onPrev: () => void;
 }
 
-export function AutotransporteSection({ data, onChange, onNext, onPrev }: AutotransporteSectionProps) {
+export function AutotransporteSection({ data, pesoTotalMercancias, onChange, onNext, onPrev }: AutotransporteSectionProps) {
   return (
     <Card>
       <AutotransporteSectionOptimizada
         data={data}
+        pesoTotalMercancias={pesoTotalMercancias}
         onChange={onChange}
         onNext={onNext}
         onPrev={onPrev}

--- a/src/components/carta-porte/autotransporte/AutotransporteSectionOptimizada.tsx
+++ b/src/components/carta-porte/autotransporte/AutotransporteSectionOptimizada.tsx
@@ -6,26 +6,33 @@ import { ArrowLeft, ArrowRight } from 'lucide-react';
 import { VehiculoSelector } from './VehiculoSelector';
 import { AutotransporteFormOptimizado } from './AutotransporteFormOptimizado';
 import { AutotransporteCompleto } from '@/types/cartaPorte';
+import { ContextualAlert } from '@/components/ui/contextual-alert';
 
 interface AutotransporteSectionOptimizadaProps {
   data: AutotransporteCompleto;
+  pesoTotalMercancias: number;
   onChange: (data: AutotransporteCompleto) => void;
   onNext: () => void;
   onPrev: () => void;
 }
 
-export function AutotransporteSectionOptimizada({ 
-  data, 
-  onChange, 
-  onNext, 
-  onPrev 
+export function AutotransporteSectionOptimizada({
+  data,
+  pesoTotalMercancias,
+  onChange,
+  onNext,
+  onPrev
 }: AutotransporteSectionOptimizadaProps) {
   const isDataValid = () => {
-    return data.placa_vm && 
-           data.num_permiso_sct && 
-           data.asegura_resp_civil && 
+    return data.placa_vm &&
+           data.num_permiso_sct &&
+           data.asegura_resp_civil &&
            data.poliza_resp_civil;
   };
+
+  const capacidadKg = (data.peso_bruto_vehicular || 0) * 1000;
+  const excedeCapacidad =
+    pesoTotalMercancias > 0 && capacidadKg > 0 && pesoTotalMercancias > capacidadKg;
 
   return (
     <>
@@ -36,6 +43,14 @@ export function AutotransporteSectionOptimizada({
         <VehiculoSelector data={data} onChange={onChange} />
         
         <AutotransporteFormOptimizado data={data} onChange={onChange} />
+
+        {excedeCapacidad && (
+          <ContextualAlert
+            type="warning"
+            message={`El peso total de la carga (${pesoTotalMercancias.toLocaleString('es-MX')} kg) supera la capacidad del vehículo (${capacidadKg.toLocaleString('es-MX')} kg).`}
+            className="mt-2"
+          />
+        )}
 
         <div className="flex justify-between pt-4">
           <Button variant="outline" onClick={onPrev} className="flex items-center space-x-2">

--- a/src/components/carta-porte/form/CartaPorteStepContent.tsx
+++ b/src/components/carta-porte/form/CartaPorteStepContent.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { ConfiguracionInicial } from '../ConfiguracionInicial';
 import { UbicacionesSection } from '../UbicacionesSection';
 import { MercanciasSection } from '../MercanciasSection';
@@ -42,6 +42,10 @@ export function CartaPorteStepContent({
   onXMLGenerated,
   onTimbrado,
 }: CartaPorteStepContentProps) {
+  const pesoTotalMercancias = useMemo(
+    () => mercancias.reduce((sum, m) => sum + (m.peso_kg || 0), 0),
+    [mercancias]
+  );
   const renderStepContent = () => {
     switch (currentStep) {
       case 0:
@@ -74,6 +78,7 @@ export function CartaPorteStepContent({
         return (
           <AutotransporteSection
             data={autotransporte}
+            pesoTotalMercancias={pesoTotalMercancias}
             onChange={onAutotransporteChange}
             onNext={() => onStepChange(4)}
             onPrev={() => onStepChange(2)}

--- a/src/components/carta-porte/form/OptimizedCartaPorteStepContent.tsx
+++ b/src/components/carta-porte/form/OptimizedCartaPorteStepContent.tsx
@@ -1,5 +1,5 @@
 
-import React, { memo } from 'react';
+import React, { memo, useMemo } from 'react';
 import { ConfiguracionInicial } from '../ConfiguracionInicial';
 import { UbicacionesSection } from '../UbicacionesSection';
 import { MercanciasSection } from '../MercanciasSection';
@@ -52,6 +52,11 @@ const OptimizedCartaPorteStepContent = memo<OptimizedCartaPorteStepContentProps>
   datosCalculoRuta,
   onCalculoRutaUpdate
 }) => {
+
+  const pesoTotalMercancias = useMemo(
+    () => mercancias.reduce((sum, m) => sum + (m.peso_kg || 0), 0),
+    [mercancias]
+  );
 
   const handleNextStep = () => {
     onStepChange(currentStep + 1);
@@ -112,6 +117,7 @@ const OptimizedCartaPorteStepContent = memo<OptimizedCartaPorteStepContentProps>
         <div className="space-y-6 bg-white p-6 rounded-lg shadow-sm border">
           <AutotransporteSection
             data={autotransporte}
+            pesoTotalMercancias={pesoTotalMercancias}
             onChange={onAutotransporteChange}
             onNext={handleNextStep}
             onPrev={handlePrevStep}


### PR DESCRIPTION
## Summary
- pass total cargo weight to Autotransporte step
- show a warning in `AutotransporteSectionOptimizada` if the cargo weight is greater than the vehicle's `peso_bruto_vehicular`

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685372b95e2c832b99f0f4c185d7ea7a