### PR TITLE
Add custom logo options for Carta Porte PDF

### DIFF
--- a/src/components/carta-porte/pdf/ProfessionalPDFSection.tsx
+++ b/src/components/carta-porte/pdf/ProfessionalPDFSection.tsx
@@ -21,14 +21,20 @@ interface ProfessionalPDFSectionProps {
     noCertificadoSAT?: string;
     noCertificadoEmisor?: string;
   } | null;
+  /** URL del logo de la empresa emisora */
+  companyLogoUrl?: string;
+  /** URL del logo del cliente opcional */
+  clientLogoUrl?: string;
   onPDFGenerated?: (pdfUrl: string) => void;
 }
 
-export function ProfessionalPDFSection({ 
-  cartaPorteData, 
+export function ProfessionalPDFSection({
+  cartaPorteData,
   xmlTimbrado,
   datosTimbre,
-  onPDFGenerated 
+  companyLogoUrl,
+  clientLogoUrl,
+  onPDFGenerated
 }: ProfessionalPDFSectionProps) {
   const {
     isGenerating,
@@ -41,7 +47,9 @@ export function ProfessionalPDFSection({
   const handleGeneratePDF = async () => {
     const result = await generateProfessionalPDF(cartaPorteData, {
       xmlTimbrado: xmlTimbrado || undefined,
-      datosTimbre: datosTimbre || undefined
+      datosTimbre: datosTimbre || undefined,
+      companyLogoUrl,
+      clientLogoUrl
     });
     
     if (result?.success && result.pdfUrl && onPDFGenerated) {


### PR DESCRIPTION
## Summary
- allow `ProfessionalPDFSection` to pass company and client logo URLs
- support company/client logos in `CartaPorteProfessionalPDF`

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68538c8877f4832b99bf26748e7fae18