### PR TITLE
Fix persistence of generated PDF and XML

### DIFF
--- a/src/hooks/usePDFGeneration.ts
+++ b/src/hooks/usePDFGeneration.ts
@@ -4,10 +4,13 @@ import { useToast } from '@/hooks/use-toast';
 import { CartaPortePDFGenerator, PDFGenerationResult } from '@/services/pdfGenerator';
 import { CartaPorteData } from '@/components/carta-porte/CartaPorteForm';
 
-export const usePDFGeneration = () => {
+export const usePDFGeneration = (
+  initialUrl: string | null = null,
+  initialBlob: Blob | null = null
+) => {
   const [isGenerating, setIsGenerating] = useState(false);
-  const [pdfUrl, setPdfUrl] = useState<string | null>(null);
-  const [pdfBlob, setPdfBlob] = useState<Blob | null>(null);
+  const [pdfUrl, setPdfUrl] = useState<string | null>(initialUrl);
+  const [pdfBlob, setPdfBlob] = useState<Blob | null>(initialBlob);
   const { toast } = useToast();
 
   const generarPDF = async (


### PR DESCRIPTION
## Summary
- allow `usePDFGeneration` to accept initial PDF data
- persist generated PDF and XML in `XMLGenerationPanel`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68539669104c832b82a7b06752fc1316