### PR TITLE
Use environment variable for Google Maps

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+VITE_GOOGLE_MAPS_API_KEY=your_key_here

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ npm install
 # Paso 4: Configurar variables de entorno
 cp .env.example .env
 # Editar .env con tus configuraciones de APIs y base de datos
+# Variables importantes:
+# - `VITE_GOOGLE_MAPS_API_KEY`: clave de la API de Google Maps
 
 # Paso 5: Iniciar servidor de desarrollo
 npm run dev

--- a/src/components/carta-porte/ubicaciones/AutoRouteCalculator.tsx
+++ b/src/components/carta-porte/ubicaciones/AutoRouteCalculator.tsx
@@ -106,8 +106,8 @@ export function AutoRouteCalculator({
     if (!routeData) return;
 
     const script = document.createElement('script');
-    // Use a valid API key placeholder - user needs to configure this
-    script.src = `https://maps.googleapis.com/maps/api/js?key=YOUR_GOOGLE_MAPS_API_KEY&libraries=geometry`;
+    const apiKey = import.meta.env.VITE_GOOGLE_MAPS_API_KEY;
+    script.src = `https://maps.googleapis.com/maps/api/js?key=${apiKey}&libraries=geometry`;
     script.async = true;
     script.defer = true;
     

--- a/src/components/carta-porte/ubicaciones/GoogleMapVisualization.tsx
+++ b/src/components/carta-porte/ubicaciones/GoogleMapVisualization.tsx
@@ -52,7 +52,8 @@ export function GoogleMapVisualization({
 
     // Create script element to load Google Maps
     const script = document.createElement('script');
-    script.src = `https://maps.googleapis.com/maps/api/js?key=AIzaSyAl1vKLZYb5h5How7tlpzrvFX2cbH4_qws&libraries=geometry&loading=async`;
+    const apiKey = import.meta.env.VITE_GOOGLE_MAPS_API_KEY;
+    script.src = `https://maps.googleapis.com/maps/api/js?key=${apiKey}&libraries=geometry&loading=async`;
     script.async = true;
     script.defer = true;
     

--- a/src/components/carta-porte/ubicaciones/StableGoogleMap.tsx
+++ b/src/components/carta-porte/ubicaciones/StableGoogleMap.tsx
@@ -110,8 +110,8 @@ export function StableGoogleMap({
     console.log('🗺️ Loading Google Maps API...');
     
     const script = document.createElement('script');
-    // Using your Google Maps API key from Supabase secrets
-    const apiKey = 'AIzaSyCYyRxDpq3lQQMvp6L7bFw7f1H1Publicaciones_interconecta'; // Tu API key configurada
+    // Use API key from environment
+    const apiKey = import.meta.env.VITE_GOOGLE_MAPS_API_KEY;
     script.src = `https://maps.googleapis.com/maps/api/js?key=${apiKey}&libraries=geometry&loading=async&callback=initGoogleMapsCallback`;
     script.async = true;
     script.defer = true;


### PR DESCRIPTION
## Summary
- add `.env.example` with a placeholder API key
- load Google Maps API key from `import.meta.env`
- document new variable in README

## Testing
- `npm run lint` *(fails: unexpected any etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6854f0e33eb4832b8b1ee87973c66060