### PR TITLE
Fix sidebar route paths

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,7 @@ import Viajes from "./pages/Viajes"
 import Remolques from "./pages/Remolques"
 import Administracion from "./pages/Administracion"
 import Planes from "./pages/Planes"
+import ConfiguracionEmpresa from "./pages/ConfiguracionEmpresa"
 
 // Nuevos componentes
 import { ViajeWizard } from "./components/viajes/ViajeWizard"
@@ -118,7 +119,15 @@ const App = () => (
                   </BaseLayout>
                 </AuthGuard>
               } />
-              
+
+              <Route path="/configuracion/empresa" element={
+                <AuthGuard>
+                  <BaseLayout>
+                    <ConfiguracionEmpresa />
+                  </BaseLayout>
+                </AuthGuard>
+              } />
+
               <Route path="/planes" element={
                 <AuthGuard>
                   <BaseLayout>

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -19,8 +19,8 @@ const sidebarItems: SidebarItem[] = [
   { title: 'Conductores', href: '/conductores', icon: Users, requiresPermission: 'conductores' },
   { title: 'Socios', href: '/socios', icon: Building2, requiresPermission: 'socios' },
   { title: 'Remolques', href: '/remolques', icon: Wrench, requiresPermission: 'vehiculos' },
-  { title: 'Carta Porte', href: '/carta-porte', icon: FileText, requiresPermission: 'cartas_porte' },
-  { title: 'Configuración', href: '/configuracion', icon: Settings }
+  { title: 'Carta Porte', href: '/cartas-porte', icon: FileText, requiresPermission: 'cartas_porte' },
+  { title: 'Configuración', href: '/configuracion/empresa', icon: Settings }
 ];
 
 export function AppSidebar() {


### PR DESCRIPTION
## Summary
- update Carta Porte and Configuración sidebar links
- add missing Configuración Empresa route

## Testing
- `npm run build`
- `npm run lint` *(fails: 873 problems)*
- `curl -I http://localhost:3000/`
- `curl -I http://localhost:3000/cartas-porte`
- `curl -I http://localhost:3000/configuracion/empresa`


------
https://chatgpt.com/codex/tasks/task_e_68577fe27a40832b8c335099d2ca8762