### PR TITLE
Add quick access button for new trip

### DIFF
--- a/src/components/GlobalHeader.tsx
+++ b/src/components/GlobalHeader.tsx
@@ -1,11 +1,14 @@
 
-import { Bell, User, LogOut, Shield, Menu } from 'lucide-react';
+import { Bell, User, LogOut, Shield, Menu, Plus } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
 import { PlanBadge } from '@/components/common/PlanBadge';
 import { useAuth } from '@/hooks/useAuth';
-import { useUnifiedPermissionsV2 } from '@/hooks/useUnifiedPermissionsV2';
+import { useUnifiedPermissions } from '@/hooks/useUnifiedPermissions';
+import { useNavigate } from 'react-router-dom';
+import { ProtectedActions } from '@/components/ProtectedActions';
+import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
 
 import { useIsMobile } from '@/hooks/use-mobile';
 
@@ -15,8 +18,13 @@ interface GlobalHeaderProps {
 
 export function GlobalHeader({ onOpenSidebar }: GlobalHeaderProps) {
   const { user, signOut } = useAuth();
-  const permissions = useUnifiedPermissionsV2();
+  const permissions = useUnifiedPermissions();
   const isMobile = useIsMobile();
+  const navigate = useNavigate();
+
+  const handleNewViaje = () => {
+    navigate('/viajes/programar');
+  };
 
   const handleSignOut = async () => {
     try {
@@ -71,14 +79,26 @@ export function GlobalHeader({ onOpenSidebar }: GlobalHeaderProps) {
           <Button variant="ghost" size="sm" className="relative">
             <Bell className="h-4 w-4" />
             {alertCount > 0 && (
-              <Badge 
-                variant="destructive" 
+              <Badge
+                variant="destructive"
                 className="absolute -top-1 -right-1 h-5 w-5 rounded-full p-0 flex items-center justify-center text-xs"
               >
                 {alertCount}
               </Badge>
             )}
           </Button>
+
+          <ProtectedActions action="create" resource="viajes" onAction={handleNewViaje}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button variant="default" size="sm" className="flex items-center gap-2">
+                  <Plus className="h-4 w-4" />
+                  <span className="hidden md:inline">Nuevo Viaje</span>
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">Nuevo Viaje</TooltipContent>
+            </Tooltip>
+          </ProtectedActions>
 
           {/* Menú de usuario */}
           <DropdownMenu>

--- a/src/components/ProtectedActions.tsx
+++ b/src/components/ProtectedActions.tsx
@@ -9,7 +9,7 @@ import { UpgradeModal } from '@/components/common/UpgradeModal';
 interface ProtectedActionsProps {
   children?: ReactNode;
   action: 'create';
-  resource: 'conductores' | 'vehiculos' | 'socios' | 'cartas_porte';
+  resource: 'conductores' | 'vehiculos' | 'socios' | 'cartas_porte' | 'viajes';
   onAction?: () => void;
   buttonText?: string;
   variant?: 'default' | 'outline' | 'ghost';

--- a/src/components/ProtectedActionsUnified.tsx
+++ b/src/components/ProtectedActionsUnified.tsx
@@ -7,7 +7,7 @@ import { Alert, AlertDescription } from '@/components/ui/alert';
 
 interface ProtectedActionsUnifiedProps {
   action: 'create';
-  resource: 'conductores' | 'vehiculos' | 'socios' | 'cartas_porte';
+  resource: 'conductores' | 'vehiculos' | 'socios' | 'cartas_porte' | 'viajes';
   onAction: () => void;
   buttonText?: string;
   variant?: 'default' | 'outline' | 'secondary';
@@ -37,6 +37,8 @@ export function ProtectedActionsUnified({
         return permissions.canCreateSocio;
       case 'cartas_porte':
         return permissions.canCreateCartaPorte;
+      case 'viajes':
+        return permissions.canCreateViaje;
       default:
         return { allowed: false, reason: 'Recurso no reconocido' };
     }

--- a/src/hooks/useUnifiedPermissions.ts
+++ b/src/hooks/useUnifiedPermissions.ts
@@ -29,6 +29,7 @@ export interface UnifiedPermissions {
   canCreateVehiculo: PermissionResult;
   canCreateSocio: PermissionResult;
   canCreateCartaPorte: PermissionResult;
+  canCreateViaje: PermissionResult;
   canUploadFile: PermissionResult;
   
   // Permisos de funcionalidades
@@ -108,6 +109,7 @@ export const useUnifiedPermissions = (): UnifiedPermissions => {
         canCreateVehiculo: { allowed: true, reason: 'Superusuario' },
         canCreateSocio: { allowed: true, reason: 'Superusuario' },
         canCreateCartaPorte: { allowed: true, reason: 'Superusuario' },
+        canCreateViaje: { allowed: true, reason: 'Superusuario' },
         canUploadFile: { allowed: true, reason: 'Superusuario' },
         
         canTimbrar: { allowed: true, reason: 'Superusuario' },
@@ -160,6 +162,7 @@ export const useUnifiedPermissions = (): UnifiedPermissions => {
         canCreateVehiculo: { allowed: true, reason: 'Período de prueba activo' },
         canCreateSocio: { allowed: true, reason: 'Período de prueba activo' },
         canCreateCartaPorte: { allowed: true, reason: 'Período de prueba activo' },
+        canCreateViaje: { allowed: true, reason: 'Período de prueba activo' },
         canUploadFile: { allowed: true, reason: 'Período de prueba activo' },
         
         canTimbrar: { allowed: true, reason: 'Período de prueba activo' },
@@ -214,6 +217,7 @@ export const useUnifiedPermissions = (): UnifiedPermissions => {
         canCreateVehiculo: { allowed: false, reason: 'Cuenta bloqueada' },
         canCreateSocio: { allowed: false, reason: 'Cuenta bloqueada' },
         canCreateCartaPorte: { allowed: false, reason: 'Cuenta bloqueada' },
+        canCreateViaje: { allowed: false, reason: 'Cuenta bloqueada' },
         canUploadFile: { allowed: false, reason: 'Cuenta bloqueada' },
         
         canTimbrar: { allowed: false, reason: 'Cuenta bloqueada' },
@@ -298,8 +302,16 @@ export const useUnifiedPermissions = (): UnifiedPermissions => {
         
         canCreateCartaPorte: {
           allowed: plan.limite_cartas_porte ? cartasPorteUsed < plan.limite_cartas_porte : true,
-          reason: plan.limite_cartas_porte ? 
-            `${cartasPorteUsed}/${plan.limite_cartas_porte} cartas de porte usadas` : 
+          reason: plan.limite_cartas_porte ?
+            `${cartasPorteUsed}/${plan.limite_cartas_porte} cartas de porte usadas` :
+            'Sin límite de cartas de porte',
+          limit: plan.limite_cartas_porte || undefined,
+          used: cartasPorteUsed
+        },
+        canCreateViaje: {
+          allowed: plan.limite_cartas_porte ? cartasPorteUsed < plan.limite_cartas_porte : true,
+          reason: plan.limite_cartas_porte ?
+            `${cartasPorteUsed}/${plan.limite_cartas_porte} cartas de porte usadas` :
             'Sin límite de cartas de porte',
           limit: plan.limite_cartas_porte || undefined,
           used: cartasPorteUsed
@@ -378,6 +390,7 @@ export const useUnifiedPermissions = (): UnifiedPermissions => {
             vehiculos: basePermissions.canCreateVehiculo,
             socios: basePermissions.canCreateSocio,
             cartas_porte: basePermissions.canCreateCartaPorte,
+            viajes: basePermissions.canCreateViaje,
             archivos: basePermissions.canUploadFile,
           };
           const permission = resourceMap[resource as keyof typeof resourceMap];
@@ -418,6 +431,7 @@ export const useUnifiedPermissions = (): UnifiedPermissions => {
         canCreateVehiculo: { allowed: false, reason: 'Período de prueba finalizado' },
         canCreateSocio: { allowed: false, reason: 'Período de prueba finalizado' },
         canCreateCartaPorte: { allowed: false, reason: 'Período de prueba finalizado' },
+        canCreateViaje: { allowed: false, reason: 'Período de prueba finalizado' },
         canUploadFile: { allowed: false, reason: 'Período de prueba finalizado' },
         
         canTimbrar: { allowed: false, reason: 'Período de prueba finalizado' },
@@ -469,6 +483,7 @@ export const useUnifiedPermissions = (): UnifiedPermissions => {
       canCreateVehiculo: { allowed: false, reason: 'No tiene plan activo' },
       canCreateSocio: { allowed: false, reason: 'No tiene plan activo' },
       canCreateCartaPorte: { allowed: false, reason: 'No tiene plan activo' },
+      canCreateViaje: { allowed: false, reason: 'No tiene plan activo' },
       canUploadFile: { allowed: false, reason: 'No tiene plan activo' },
       
       canTimbrar: { allowed: false, reason: 'No tiene plan activo' },


### PR DESCRIPTION
## Summary
- add `canCreateViaje` permission
- support `viajes` resource in `ProtectedActions` and `ProtectedActionsUnified`
- add responsive "Nuevo Viaje" button in `GlobalHeader`

## Testing
- `npm run lint` *(fails: @typescript-eslint errors)*
- `npm run build:dev`


------
https://chatgpt.com/codex/tasks/task_e_6859e749cd1c832baa6b216cdcabcf7b