### PR TITLE
Open ViajeWizard in modal

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,8 +6,10 @@ import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom"
 import { AuthProvider } from "./hooks/useAuth"
 import { AuthGuard } from "./components/auth/AuthGuard"
 import { BaseLayout } from "./components/layout/BaseLayout"
-import { OnboardingProvider } from '@/contexts/OnboardingProvider';
-import { OnboardingIntegration } from '@/components/onboarding/OnboardingIntegration';
+import { OnboardingProvider } from '@/contexts/OnboardingProvider'
+import { OnboardingIntegration } from '@/components/onboarding/OnboardingIntegration'
+import { ViajeWizardModalProvider } from '@/contexts/ViajeWizardModalProvider'
+import { ViajeWizardModal } from '@/components/viajes/ViajeWizardModal'
 
 // Páginas públicas
 import Index from "./pages/Index"
@@ -37,9 +39,11 @@ const App = () => (
       <Toaster />
       <BrowserRouter>
         <AuthProvider>
-          <OnboardingProvider>
-            <OnboardingIntegration />
-            <Routes>
+          <ViajeWizardModalProvider>
+            <OnboardingProvider>
+              <OnboardingIntegration />
+              <ViajeWizardModal />
+              <Routes>
               {/* Página principal - Landing page para usuarios no autenticados */}
               <Route path="/" element={<Index />} />
               
@@ -156,6 +160,7 @@ const App = () => (
               <Route path="*" element={<Navigate to="/" replace />} />
             </Routes>
           </OnboardingProvider>
+        </ViajeWizardModalProvider>
         </AuthProvider>
       </BrowserRouter>
     </TooltipProvider>

--- a/src/components/GlobalHeader.tsx
+++ b/src/components/GlobalHeader.tsx
@@ -7,6 +7,7 @@ import { PlanBadge } from '@/components/common/PlanBadge';
 import { useAuth } from '@/hooks/useAuth';
 import { useUnifiedPermissions } from '@/hooks/useUnifiedPermissions';
 import { useNavigate } from 'react-router-dom';
+import { useViajeWizardModal } from '@/contexts/ViajeWizardModalProvider';
 import { ProtectedActions } from '@/components/ProtectedActions';
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
 
@@ -21,9 +22,10 @@ export function GlobalHeader({ onOpenSidebar }: GlobalHeaderProps) {
   const permissions = useUnifiedPermissions();
   const isMobile = useIsMobile();
   const navigate = useNavigate();
+  const { openViajeWizard } = useViajeWizardModal();
 
   const handleNewViaje = () => {
-    navigate('/viajes/programar');
+    openViajeWizard();
   };
 
   const handleSignOut = async () => {

--- a/src/components/viajes/ViajeWizard.tsx
+++ b/src/components/viajes/ViajeWizard.tsx
@@ -69,7 +69,12 @@ const STEPS = [
   }
 ];
 
-export function ViajeWizard() {
+interface ViajeWizardProps {
+  onCancel?: () => void
+  onComplete?: () => void
+}
+
+export function ViajeWizard({ onCancel, onComplete }: ViajeWizardProps) {
   const navigate = useNavigate();
   const { crearViaje, isCreatingViaje } = useViajes();
   const { 
@@ -139,7 +144,11 @@ export function ViajeWizard() {
   };
 
   const handleCancel = () => {
-    navigate('/viajes');
+    if (onCancel) {
+      onCancel();
+    } else {
+      navigate('/viajes');
+    }
   };
 
   const handleConfirmarViaje = async () => {
@@ -183,13 +192,17 @@ export function ViajeWizard() {
 
       // 3. Redirigir después de un breve delay
       setTimeout(() => {
-        navigate('/viajes', { 
-          state: { 
-            message: 'Viaje programado y documentos generados exitosamente',
-            viajeId: nuevoViaje.id,
-            cartaPorteId: resultado.carta_porte.id
-          }
-        });
+        if (onComplete) {
+          onComplete();
+        } else {
+          navigate('/viajes', {
+            state: {
+              message: 'Viaje programado y documentos generados exitosamente',
+              viajeId: nuevoViaje.id,
+              cartaPorteId: resultado.carta_porte.id
+            }
+          });
+        }
       }, 2000);
 
     } catch (error) {

--- a/src/components/viajes/ViajeWizardModal.tsx
+++ b/src/components/viajes/ViajeWizardModal.tsx
@@ -1,0 +1,15 @@
+import { ResponsiveDialog, ResponsiveDialogContent } from '@/components/ui/responsive-dialog'
+import { ViajeWizard } from './ViajeWizard'
+import { useViajeWizardModal } from '@/contexts/ViajeWizardModalProvider'
+
+export function ViajeWizardModal() {
+  const { isViajeWizardOpen, closeViajeWizard } = useViajeWizardModal()
+
+  return (
+    <ResponsiveDialog open={isViajeWizardOpen} onOpenChange={(open) => { if(!open) closeViajeWizard() }}>
+      <ResponsiveDialogContent className="md:max-w-5xl inset-0 h-screen md:h-auto md:inset-auto" >
+        <ViajeWizard onCancel={closeViajeWizard} onComplete={closeViajeWizard} />
+      </ResponsiveDialogContent>
+    </ResponsiveDialog>
+  )
+}

--- a/src/contexts/ViajeWizardModalProvider.tsx
+++ b/src/contexts/ViajeWizardModalProvider.tsx
@@ -1,0 +1,30 @@
+import { createContext, useContext, useState } from 'react'
+
+interface ViajeWizardModalContextType {
+  isViajeWizardOpen: boolean
+  openViajeWizard: () => void
+  closeViajeWizard: () => void
+}
+
+const ViajeWizardModalContext = createContext<ViajeWizardModalContextType | undefined>(undefined)
+
+export function ViajeWizardModalProvider({ children }: { children: React.ReactNode }) {
+  const [isViajeWizardOpen, setIsViajeWizardOpen] = useState(false)
+
+  const openViajeWizard = () => setIsViajeWizardOpen(true)
+  const closeViajeWizard = () => setIsViajeWizardOpen(false)
+
+  return (
+    <ViajeWizardModalContext.Provider value={{ isViajeWizardOpen, openViajeWizard, closeViajeWizard }}>
+      {children}
+    </ViajeWizardModalContext.Provider>
+  )
+}
+
+export function useViajeWizardModal() {
+  const context = useContext(ViajeWizardModalContext)
+  if (!context) {
+    throw new Error('useViajeWizardModal must be used within a ViajeWizardModalProvider')
+  }
+  return context
+}


### PR DESCRIPTION
## Summary
- create ViajeWizardModalProvider global context
- open ViajeWizard inside new ViajeWizardModal component
- show the modal from GlobalHeader instead of navigating
- allow ViajeWizard to close via props
- mount modal provider in App layout

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build:dev` *(fails: vite not found)*


------
https://chatgpt.com/codex/tasks/task_e_685a014925c0832b93b51ff372c48539