### PR TITLE
Fix ViajeWizard flow

### DIFF
--- a/src/components/viajes/modals/ProgramarViajeModal.tsx
+++ b/src/components/viajes/modals/ProgramarViajeModal.tsx
@@ -1,4 +1,7 @@
 
+/**
+ * @deprecated Este componente ha sido reemplazado por el flujo completo de ViajeWizard.tsx. No utilizar.
+ */
 import { useState } from 'react';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';

--- a/src/pages/ViajesOptimized.tsx
+++ b/src/pages/ViajesOptimized.tsx
@@ -7,7 +7,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { ViajesActivos } from '@/components/viajes/ViajesActivos';
 import { ViajesHistorial } from '@/components/viajes/ViajesHistorial';
-import { ViajeFormDialog } from '@/components/viajes/ViajeFormDialog';
+import { useViajeWizardModal } from '@/contexts/ViajeWizardModalProvider';
 import { useViajes } from '@/hooks/useViajes';
 import { useUnifiedPermissionsV2 } from '@/hooks/useUnifiedPermissionsV2';
 import { ProtectedContent } from '@/components/ProtectedContent';
@@ -18,8 +18,8 @@ export default function ViajesOptimized() {
   const { viajes, isLoading } = useViajes();
   const permissions = useUnifiedPermissionsV2();
   const [searchTerm, setSearchTerm] = useState('');
-  const [showCreateDialog, setShowCreateDialog] = useState(false);
   const [activeTab, setActiveTab] = useState('activos');
+  const { openViajeWizard } = useViajeWizardModal();
 
   const handleNewViaje = () => {
     console.log('[Viajes] 🆕 Iniciando programación de nuevo viaje');
@@ -31,7 +31,7 @@ export default function ViajesOptimized() {
       return;
     }
     
-    setShowCreateDialog(true);
+    openViajeWizard();
   };
 
   const canCreateViaje = permissions.canCreateConductor; // Using conductor permission as placeholder
@@ -144,15 +144,6 @@ export default function ViajesOptimized() {
           </TabsContent>
         </Tabs>
 
-        {/* Diálogos */}
-        <ViajeFormDialog
-          open={showCreateDialog}
-          onOpenChange={setShowCreateDialog}
-          onSuccess={() => {
-            setShowCreateDialog(false);
-            setActiveTab('activos');
-          }}
-        />
       </div>
     </ProtectedContent>
   );


### PR DESCRIPTION
## Summary
- open full ViajeWizard from `Viajes` page
- mark `ProgramarViajeModal` as deprecated

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685a0797f74c832b982407ea1e060cb7