### PR TITLE
Unify trial remaining days via unified permissions

### DIFF
--- a/src/components/suscripcion/EstadoSuscripcion.tsx
+++ b/src/components/suscripcion/EstadoSuscripcion.tsx
@@ -1,50 +1,74 @@
-
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
-import { useSuscripcion } from '@/hooks/useSuscripcion';
-import { LimitUsageIndicator } from '@/components/LimitUsageIndicator';
-import { PlanSummaryCard } from './PlanSummaryCard';
-import { Clock, AlertTriangle, CheckCircle, XCircle, RefreshCw, Settings } from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { useSuscripcion } from "@/hooks/useSuscripcion";
+import { useUnifiedPermissions } from "@/hooks/useUnifiedPermissions";
+import { LimitUsageIndicator } from "@/components/LimitUsageIndicator";
+import { PlanSummaryCard } from "./PlanSummaryCard";
+import {
+  Clock,
+  AlertTriangle,
+  CheckCircle,
+  XCircle,
+  RefreshCw,
+  Settings,
+} from "lucide-react";
 
 export const EstadoSuscripcion = () => {
-  const { 
-    suscripcion, 
-    enPeriodoPrueba, 
-    diasRestantesPrueba, 
-    suscripcionVencida,
-    estaBloqueado,
+  const {
+    suscripcion,
     verificarSuscripcion,
     isVerifyingSubscription,
     abrirPortalCliente,
-    isOpeningPortal
+    isOpeningPortal,
   } = useSuscripcion();
+  const permissions = useUnifiedPermissions();
 
   if (!suscripcion) return null;
 
   const getStatusBadge = () => {
-    if (estaBloqueado) {
-      return <Badge variant="destructive"><XCircle className="w-3 h-3 mr-1" />Bloqueado</Badge>;
+    if (permissions.accessLevel === "blocked") {
+      return (
+        <Badge variant="destructive">
+          <XCircle className="w-3 h-3 mr-1" />
+          Bloqueado
+        </Badge>
+      );
     }
-    
-    if (suscripcionVencida()) {
-      return <Badge variant="destructive"><AlertTriangle className="w-3 h-3 mr-1" />Vencido</Badge>;
+
+    if (permissions.accessLevel === "expired") {
+      return (
+        <Badge variant="destructive">
+          <AlertTriangle className="w-3 h-3 mr-1" />
+          Vencido
+        </Badge>
+      );
     }
-    
-    if (enPeriodoPrueba()) {
-      return <Badge variant="secondary"><Clock className="w-3 h-3 mr-1" />Período de Prueba</Badge>;
+
+    if (permissions.accessLevel === "trial") {
+      return (
+        <Badge variant="secondary">
+          <Clock className="w-3 h-3 mr-1" />
+          Período de Prueba
+        </Badge>
+      );
     }
-    
-    if (suscripcion.status === 'active') {
-      return <Badge variant="default"><CheckCircle className="w-3 h-3 mr-1" />Activo</Badge>;
+
+    if (suscripcion.status === "active") {
+      return (
+        <Badge variant="default">
+          <CheckCircle className="w-3 h-3 mr-1" />
+          Activo
+        </Badge>
+      );
     }
-    
+
     return <Badge variant="outline">{suscripcion.status}</Badge>;
   };
 
   const formatDate = (dateString?: string) => {
-    if (!dateString) return 'No definida';
-    return new Date(dateString).toLocaleDateString('es-MX');
+    if (!dateString) return "No definida";
+    return new Date(dateString).toLocaleDateString("es-MX");
   };
 
   const handleVerificarSuscripcion = () => {
@@ -72,7 +96,7 @@ export const EstadoSuscripcion = () => {
           <div className="grid grid-cols-2 gap-4 text-sm">
             <div>
               <span className="font-medium">Plan actual:</span>
-              <p>{suscripcion.plan?.nombre || 'Sin plan'}</p>
+              <p>{suscripcion.plan?.nombre || "Sin plan"}</p>
             </div>
             <div>
               <span className="font-medium">Fecha de vencimiento:</span>
@@ -80,20 +104,25 @@ export const EstadoSuscripcion = () => {
             </div>
           </div>
 
-          {enPeriodoPrueba() && (
+          {permissions.accessLevel === "trial" && (
             <div className="bg-blue-50 p-3 rounded-lg">
               <p className="text-sm text-blue-800">
                 <Clock className="inline w-4 h-4 mr-1" />
-                Te quedan <strong>{diasRestantesPrueba()} días</strong> de período de prueba
+                Te quedan{" "}
+                <strong>
+                  {permissions.planInfo.daysRemaining || 0} días
+                </strong>{" "}
+                de período de prueba
               </p>
             </div>
           )}
 
-          {suscripcionVencida() && (
+          {permissions.accessLevel === "expired" && (
             <div className="bg-red-50 p-3 rounded-lg">
               <p className="text-sm text-red-800">
                 <AlertTriangle className="inline w-4 h-4 mr-1" />
-                Su suscripción ha vencido. Renueve para continuar usando la plataforma.
+                Su suscripción ha vencido. Renueve para continuar usando la
+                plataforma.
               </p>
             </div>
           )}
@@ -106,11 +135,13 @@ export const EstadoSuscripcion = () => {
               size="sm"
               className="flex-1"
             >
-              <RefreshCw className={`w-4 h-4 mr-2 ${isVerifyingSubscription ? 'animate-spin' : ''}`} />
-              {isVerifyingSubscription ? 'Verificando...' : 'Verificar Estado'}
+              <RefreshCw
+                className={`w-4 h-4 mr-2 ${isVerifyingSubscription ? "animate-spin" : ""}`}
+              />
+              {isVerifyingSubscription ? "Verificando..." : "Verificar Estado"}
             </Button>
 
-            {suscripcion.status === 'active' && (
+            {suscripcion.status === "active" && (
               <Button
                 onClick={handleAbrirPortal}
                 disabled={isOpeningPortal}
@@ -119,7 +150,7 @@ export const EstadoSuscripcion = () => {
                 className="flex-1"
               >
                 <Settings className="w-4 h-4 mr-2" />
-                {isOpeningPortal ? 'Abriendo...' : 'Gestionar'}
+                {isOpeningPortal ? "Abriendo..." : "Gestionar"}
               </Button>
             )}
           </div>

--- a/src/components/suscripcion/ModalBloqueoFaltaPago.tsx
+++ b/src/components/suscripcion/ModalBloqueoFaltaPago.tsx
@@ -1,14 +1,24 @@
-
-import { useEffect, useState } from 'react';
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
-import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { Alert, AlertDescription } from '@/components/ui/alert';
-import { useSuscripcion } from '@/hooks/useSuscripcion';
-import { AlertTriangle, CreditCard, Clock } from 'lucide-react';
+import { useEffect, useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { useSuscripcion } from "@/hooks/useSuscripcion";
+import { AlertTriangle, CreditCard, Clock } from "lucide-react";
 
 export const ModalBloqueoFaltaPago = () => {
-  const { bloqueo, suscripcion, diasRestantesPrueba, suscripcionVencida } = useSuscripcion();
+  const { bloqueo, suscripcion, suscripcionVencida } = useSuscripcion();
   const [isOpen, setIsOpen] = useState(false);
 
   useEffect(() => {
@@ -22,12 +32,12 @@ export const ModalBloqueoFaltaPago = () => {
 
   const handlePayment = () => {
     // Redirigir a la página de pagos o abrir Stripe
-    window.location.href = '/pagos';
+    window.location.href = "/pagos";
   };
 
   const handleUpgradePlan = () => {
     // Redirigir a la página de planes
-    window.location.href = '/planes';
+    window.location.href = "/planes";
   };
 
   if (!isOpen) return null;
@@ -38,7 +48,7 @@ export const ModalBloqueoFaltaPago = () => {
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2 text-red-600">
             <AlertTriangle className="h-5 w-5" />
-            {bloqueo?.activo ? 'Cuenta Bloqueada' : 'Suscripción Vencida'}
+            {bloqueo?.activo ? "Cuenta Bloqueada" : "Suscripción Vencida"}
           </DialogTitle>
         </DialogHeader>
 
@@ -47,7 +57,8 @@ export const ModalBloqueoFaltaPago = () => {
             <Alert variant="destructive">
               <AlertTriangle className="h-4 w-4" />
               <AlertDescription>
-                {bloqueo.mensaje_bloqueo || 'Su cuenta ha sido bloqueada por falta de pago.'}
+                {bloqueo.mensaje_bloqueo ||
+                  "Su cuenta ha sido bloqueada por falta de pago."}
               </AlertDescription>
             </Alert>
           )}
@@ -56,7 +67,8 @@ export const ModalBloqueoFaltaPago = () => {
             <Alert variant="destructive">
               <Clock className="h-4 w-4" />
               <AlertDescription>
-                Su período de prueba ha expirado. Para continuar usando la plataforma, seleccione un plan de pago.
+                Su período de prueba ha expirado. Para continuar usando la
+                plataforma, seleccione un plan de pago.
               </AlertDescription>
             </Alert>
           )}
@@ -69,20 +81,18 @@ export const ModalBloqueoFaltaPago = () => {
               </CardDescription>
             </CardHeader>
             <CardContent className="space-y-3">
-              {suscripcion?.status === 'past_due' && (
-                <Button 
-                  onClick={handlePayment}
-                  className="w-full"
-                  size="lg"
-                >
+              {suscripcion?.status === "past_due" && (
+                <Button onClick={handlePayment} className="w-full" size="lg">
                   <CreditCard className="mr-2 h-4 w-4" />
                   Realizar Pago Pendiente
                 </Button>
               )}
 
-              <Button 
+              <Button
                 onClick={handleUpgradePlan}
-                variant={suscripcion?.status === 'past_due' ? 'outline' : 'default'}
+                variant={
+                  suscripcion?.status === "past_due" ? "outline" : "default"
+                }
                 className="w-full"
                 size="lg"
               >

--- a/src/components/suscripcion/PlanSummaryCard.tsx
+++ b/src/components/suscripcion/PlanSummaryCard.tsx
@@ -1,36 +1,27 @@
-
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
-import { useSuscripcion } from '@/hooks/useSuscripcion';
-import { useUnifiedPermissionsV2 } from '@/hooks/useUnifiedPermissionsV2';
-import { LimitUsageIndicator } from '@/components/common/LimitUsageIndicator';
-import { Crown, Zap, Clock, Settings, AlertTriangle } from 'lucide-react';
-import { Link } from 'react-router-dom';
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { useSuscripcion } from "@/hooks/useSuscripcion";
+import { useUnifiedPermissions } from "@/hooks/useUnifiedPermissions";
+import { LimitUsageIndicator } from "@/components/common/LimitUsageIndicator";
+import { Crown, Zap, Clock, Settings, AlertTriangle } from "lucide-react";
+import { Link } from "react-router-dom";
 
 export const PlanSummaryCard = () => {
-  const { 
-    suscripcion, 
-    enPeriodoPrueba, 
-    diasRestantesPrueba,
-    suscripcionVencida,
-    estaBloqueado,
-    abrirPortalCliente,
-    isOpeningPortal
-  } = useSuscripcion();
-  
-  const permissions = useUnifiedPermissionsV2();
+  const { suscripcion, abrirPortalCliente, isOpeningPortal } = useSuscripcion();
+  const permissions = useUnifiedPermissions();
 
   if (!suscripcion) return null;
 
   const getPlanIcon = () => {
-    if (enPeriodoPrueba()) return <Clock className="h-4 w-4" />;
-    
+    if (permissions.accessLevel === "trial")
+      return <Clock className="h-4 w-4" />;
+
     switch (suscripcion.plan?.nombre) {
-      case 'Básico':
+      case "Básico":
         return <Zap className="h-4 w-4" />;
-      case 'Profesional':
-      case 'Empresarial':
+      case "Profesional":
+      case "Empresarial":
         return <Crown className="h-4 w-4" />;
       default:
         return <Zap className="h-4 w-4" />;
@@ -38,33 +29,41 @@ export const PlanSummaryCard = () => {
   };
 
   const getPlanColor = () => {
-    if (estaBloqueado || suscripcionVencida()) return 'destructive';
-    if (enPeriodoPrueba()) return 'secondary';
-    
+    if (
+      permissions.accessLevel === "blocked" ||
+      permissions.accessLevel === "expired"
+    )
+      return "destructive";
+    if (permissions.accessLevel === "trial") return "secondary";
+
     switch (suscripcion.plan?.nombre) {
-      case 'Básico':
-        return 'outline';
-      case 'Profesional':
-        return 'default';
-      case 'Empresarial':
-        return 'default';
+      case "Básico":
+        return "outline";
+      case "Profesional":
+        return "default";
+      case "Empresarial":
+        return "default";
       default:
-        return 'outline';
+        return "outline";
     }
   };
 
   const getStatusMessage = () => {
-    if (estaBloqueado) return '¡Cuenta bloqueada por falta de pago!';
-    if (suscripcionVencida()) return '¡Suscripción vencida!';
-    if (enPeriodoPrueba()) {
-      const dias = diasRestantesPrueba();
-      return `${dias} día${dias !== 1 ? 's' : ''} restante${dias !== 1 ? 's' : ''} de prueba`;
+    if (permissions.accessLevel === "blocked")
+      return "¡Cuenta bloqueada por falta de pago!";
+    if (permissions.accessLevel === "expired") return "¡Suscripción vencida!";
+    if (permissions.accessLevel === "trial") {
+      const dias = permissions.planInfo.daysRemaining || 0;
+      return `${dias} día${dias !== 1 ? "s" : ""} restante${dias !== 1 ? "s" : ""} de prueba`;
     }
-    return 'Suscripción activa';
+    return "Suscripción activa";
   };
 
   const showUpgradePrompt = () => {
-    return enPeriodoPrueba() || suscripcion.plan?.nombre === 'Básico';
+    return (
+      permissions.accessLevel === "trial" ||
+      suscripcion.plan?.nombre === "Básico"
+    );
   };
 
   const handlePortalClick = () => {
@@ -77,10 +76,12 @@ export const PlanSummaryCard = () => {
         <div className="flex items-center justify-between">
           <CardTitle className="flex items-center gap-2">
             {getPlanIcon()}
-            Plan {suscripcion.plan?.nombre || 'Desconocido'}
+            Plan {suscripcion.plan?.nombre || "Desconocido"}
           </CardTitle>
           <Badge variant={getPlanColor()} className="flex items-center gap-1">
-            {estaBloqueado && <AlertTriangle className="h-3 w-3" />}
+            {permissions.accessLevel === "blocked" && (
+              <AlertTriangle className="h-3 w-3" />
+            )}
             {getStatusMessage()}
           </Badge>
         </div>
@@ -91,10 +92,10 @@ export const PlanSummaryCard = () => {
           {Object.entries(permissions.usage).map(([key, data]) => (
             <div key={key} className="space-y-1">
               <div className="text-xs font-medium text-muted-foreground capitalize">
-                {key.replace('_', ' ')}
+                {key.replace("_", " ")}
               </div>
-              <LimitUsageIndicator 
-                resourceType={key as any} 
+              <LimitUsageIndicator
+                resourceType={key as any}
                 showDetails={false}
                 className="text-xs"
               />
@@ -112,17 +113,17 @@ export const PlanSummaryCard = () => {
               </Button>
             </Link>
           )}
-          
-          {suscripcion.status === 'active' && (
+
+          {suscripcion.status === "active" && (
             <Button
               onClick={handlePortalClick}
               disabled={isOpeningPortal}
               variant="outline"
               size="sm"
-              className={showUpgradePrompt() ? '' : 'flex-1'}
+              className={showUpgradePrompt() ? "" : "flex-1"}
             >
               <Settings className="h-3 w-3 mr-1" />
-              {isOpeningPortal ? 'Abriendo...' : 'Gestionar'}
+              {isOpeningPortal ? "Abriendo..." : "Gestionar"}
             </Button>
           )}
         </div>
@@ -130,14 +131,19 @@ export const PlanSummaryCard = () => {
         {/* Mensaje de alerta si está cerca de límites */}
         {Object.entries(permissions.usage).some(([_, data]) => {
           if (data.limit === null) return false;
-          return (data.used / data.limit) >= 0.8;
+          return data.used / data.limit >= 0.8;
         }) && (
           <div className="bg-orange-50 border border-orange-200 rounded-lg p-3">
             <div className="flex items-start gap-2">
               <AlertTriangle className="h-4 w-4 text-orange-600 mt-0.5 flex-shrink-0" />
               <div className="text-xs text-orange-800">
-                <p className="font-medium">Te estás acercando a los límites de tu plan</p>
-                <p>Considera actualizar para evitar interrupciones en el servicio.</p>
+                <p className="font-medium">
+                  Te estás acercando a los límites de tu plan
+                </p>
+                <p>
+                  Considera actualizar para evitar interrupciones en el
+                  servicio.
+                </p>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- use `useUnifiedPermissions` as single source for trial information
- refactor PlanSummaryCard to read trial status from unified hook
- refactor EstadoSuscripcion similarly
- clean unused `diasRestantesPrueba` import

## Testing
- `npx vitest run` *(fails: Need to install the following packages: vitest@3.2.4)*

------
https://chatgpt.com/codex/tasks/task_e_685a0a6f155c832bb8aafd5dc716045f