### PR TITLE
Improve address form UX

### DIFF
--- a/src/components/administracion/configuracion/DatosFiscalesForm.tsx
+++ b/src/components/administracion/configuracion/DatosFiscalesForm.tsx
@@ -161,9 +161,8 @@ export function DatosFiscalesForm() {
               <Input
                 id="estado"
                 {...form.register('estado')}
-                placeholder="Jalisco"
+                placeholder="Se autocompleta con el C.P."
                 readOnly
-                className="bg-gray-50"
               />
             </div>
 
@@ -172,9 +171,8 @@ export function DatosFiscalesForm() {
               <Input
                 id="municipio"
                 {...form.register('municipio')}
-                placeholder="Guadalajara"
+                placeholder="Se autocompleta con el C.P."
                 readOnly
-                className="bg-gray-50"
               />
             </div>
           </div>

--- a/src/components/carta-porte/ubicaciones/SmartUbicacionFormV2.tsx
+++ b/src/components/carta-porte/ubicaciones/SmartUbicacionFormV2.tsx
@@ -494,8 +494,8 @@ export function SmartUbicacionFormV2({
                     id="pais"
                     value={formData.domicilio.pais}
                     onChange={(e) => handleFieldChange('domicilio.pais', e.target.value)}
-                    disabled={isFieldLocked('pais')}
-                    className={isFieldLocked('pais') ? 'bg-gray-100' : 'bg-white'}
+                    readOnly={isFieldLocked('pais')}
+                    className="bg-white"
                   />
                 </div>
 
@@ -505,8 +505,9 @@ export function SmartUbicacionFormV2({
                     id="codigoPostal"
                     value={formData.domicilio.codigoPostal}
                     onChange={(e) => handleFieldChange('domicilio.codigoPostal', e.target.value)}
-                    disabled={isFieldLocked('codigoPostal')}
-                    className={`${isFieldLocked('codigoPostal') ? 'bg-gray-100' : 'bg-white'} ${errors.codigoPostal ? 'border-red-500' : ''}`}
+                    readOnly={isFieldLocked('codigoPostal')}
+                    placeholder={isFieldLocked('codigoPostal') && !formData.domicilio.codigoPostal ? 'Se autocompleta con el C.P.' : ''}
+                    className={`${errors.codigoPostal ? 'border-red-500' : ''} bg-white`}
                   />
                   {errors.codigoPostal && <p className="text-sm text-red-500 mt-1">{errors.codigoPostal}</p>}
                 </div>
@@ -517,8 +518,9 @@ export function SmartUbicacionFormV2({
                     id="estado"
                     value={formData.domicilio.estado}
                     onChange={(e) => handleFieldChange('domicilio.estado', e.target.value)}
-                    disabled={isFieldLocked('estado')}
-                    className={`${isFieldLocked('estado') ? 'bg-gray-100' : 'bg-white'} ${errors.estado ? 'border-red-500' : ''}`}
+                    readOnly={isFieldLocked('estado')}
+                    placeholder={isFieldLocked('estado') && !formData.domicilio.estado ? 'Se autocompleta con el C.P.' : 'Estado'}
+                    className={`${errors.estado ? 'border-red-500' : ''} bg-white`}
                   />
                   {errors.estado && <p className="text-sm text-red-500 mt-1">{errors.estado}</p>}
                 </div>
@@ -531,8 +533,9 @@ export function SmartUbicacionFormV2({
                     id="municipio"
                     value={formData.domicilio.municipio}
                     onChange={(e) => handleFieldChange('domicilio.municipio', e.target.value)}
-                    disabled={isFieldLocked('municipio')}
-                    className={`${isFieldLocked('municipio') ? 'bg-gray-100' : 'bg-white'} ${errors.municipio ? 'border-red-500' : ''}`}
+                    readOnly={isFieldLocked('municipio')}
+                    placeholder={isFieldLocked('municipio') && !formData.domicilio.municipio ? 'Se autocompleta con el C.P.' : 'Municipio'}
+                    className={`${errors.municipio ? 'border-red-500' : ''} bg-white`}
                   />
                   {errors.municipio && <p className="text-sm text-red-500 mt-1">{errors.municipio}</p>}
                 </div>
@@ -544,8 +547,9 @@ export function SmartUbicacionFormV2({
                     value={formData.domicilio.colonia}
                     onChange={(e) => handleFieldChange('domicilio.colonia', e.target.value)}
                     placeholder="Colonia"
-                    disabled={isFieldLocked('colonia')}
-                    className={isFieldLocked('colonia') ? 'bg-gray-100' : 'bg-white'}
+                    readOnly={isFieldLocked('colonia')}
+                    placeholder={isFieldLocked('colonia') && !formData.domicilio.colonia ? 'Se autocompleta con el C.P.' : 'Colonia'}
+                    className="bg-white"
                   />
                 </div>
               </div>
@@ -557,8 +561,8 @@ export function SmartUbicacionFormV2({
                     id="calle"
                     value={formData.domicilio.calle}
                     onChange={(e) => handleFieldChange('domicilio.calle', e.target.value)}
-                    disabled={isFieldLocked('calle')}
-                    className={`${isFieldLocked('calle') ? 'bg-gray-100' : 'bg-white'} ${errors.calle ? 'border-red-500' : ''}`}
+                    readOnly={isFieldLocked('calle')}
+                    className={`${errors.calle ? 'border-red-500' : ''} bg-white`}
                   />
                   {errors.calle && <p className="text-sm text-red-500 mt-1">{errors.calle}</p>}
                 </div>
@@ -569,8 +573,8 @@ export function SmartUbicacionFormV2({
                     id="numExterior"
                     value={formData.domicilio.numExterior}
                     onChange={(e) => handleFieldChange('domicilio.numExterior', e.target.value)}
-                    disabled={isFieldLocked('numExterior')}
-                    className={isFieldLocked('numExterior') ? 'bg-gray-100' : 'bg-white'}
+                    readOnly={isFieldLocked('numExterior')}
+                    className="bg-white"
                   />
                 </div>
 
@@ -581,8 +585,8 @@ export function SmartUbicacionFormV2({
                     value={formData.domicilio.numInterior}
                     onChange={(e) => handleFieldChange('domicilio.numInterior', e.target.value)}
                     placeholder="Ej: 1A, Local 2"
-                    disabled={isFieldLocked('numInterior')}
-                    className={isFieldLocked('numInterior') ? 'bg-gray-100' : 'bg-white'}
+                    readOnly={isFieldLocked('numInterior')}
+                    className="bg-white"
                   />
                 </div>
               </div>
@@ -595,8 +599,9 @@ export function SmartUbicacionFormV2({
                     value={formData.domicilio.localidad}
                     onChange={(e) => handleFieldChange('domicilio.localidad', e.target.value)}
                     placeholder="Localidad o población"
-                    disabled={isFieldLocked('localidad')}
-                    className={isFieldLocked('localidad') ? 'bg-gray-100' : 'bg-white'}
+                    readOnly={isFieldLocked('localidad')}
+                    placeholder={isFieldLocked('localidad') && !formData.domicilio.localidad ? 'Se autocompleta con el C.P.' : 'Localidad'}
+                    className="bg-white"
                   />
                 </div>
 
@@ -607,8 +612,8 @@ export function SmartUbicacionFormV2({
                     value={formData.domicilio.referencia}
                     onChange={(e) => handleFieldChange('domicilio.referencia', e.target.value)}
                     placeholder="Ej: Entre calles, color de fachada"
-                    disabled={isFieldLocked('referencia')}
-                    className={isFieldLocked('referencia') ? 'bg-gray-100' : 'bg-white'}
+                    readOnly={isFieldLocked('referencia')}
+                    className="bg-white"
                   />
                 </div>
               </div>

--- a/src/components/common/FormularioDomicilioUnificado.tsx
+++ b/src/components/common/FormularioDomicilioUnificado.tsx
@@ -128,10 +128,17 @@ export function FormularioDomicilioUnificado({
     usarSugerencia(cp);
   }, [onDomicilioChange, usarSugerencia]);
 
-  const isValid = useMemo(() => 
+  const isValid = useMemo(() =>
     domicilio.codigoPostal.length === 5 && !isLoading && !error && direccionInfo,
     [domicilio.codigoPostal, isLoading, error, direccionInfo]
   );
+
+  const status = useMemo(() => {
+    if (isLoading) return 'loading';
+    if (error) return 'error';
+    if (direccionInfo) return 'success';
+    return 'initial';
+  }, [isLoading, error, direccionInfo]);
 
   const esOpcional = useCallback((campo: keyof DomicilioUnificado) => 
     camposOpcionales.includes(campo), [camposOpcionales]);
@@ -235,26 +242,32 @@ export function FormularioDomicilioUnificado({
 
       {/* Estado y Municipio */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <div className="space-y-2">
+        <div className="space-y-2 relative">
           <Label>Estado *</Label>
           <Input
             value={domicilio.estado}
             onChange={(e) => onDomicilioChange('estado', e.target.value)}
-            placeholder="Estado"
-            className="bg-white border-gray-100 text-gray-900 shadow-sm"
+            placeholder={status === 'initial' ? 'Se autocompleta con el C.P.' : 'Estado'}
+            className="bg-white border-gray-100 text-gray-900 shadow-sm pr-10"
             readOnly
           />
+          {status === 'loading' && (
+            <Loader2 className="absolute right-3 top-1/2 -translate-y-1/2 h-4 w-4 animate-spin text-blue-600" />
+          )}
         </div>
 
-        <div className="space-y-2">
+        <div className="space-y-2 relative">
           <Label>Municipio *</Label>
           <Input
             value={domicilio.municipio}
             onChange={(e) => onDomicilioChange('municipio', e.target.value)}
-            placeholder="Municipio"
-            className="bg-white border-gray-100 text-gray-900 shadow-sm"
+            placeholder={status === 'initial' ? 'Se autocompleta con el C.P.' : 'Municipio'}
+            className="bg-white border-gray-100 text-gray-900 shadow-sm pr-10"
             readOnly
           />
+          {status === 'loading' && (
+            <Loader2 className="absolute right-3 top-1/2 -translate-y-1/2 h-4 w-4 animate-spin text-blue-600" />
+          )}
         </div>
       </div>
 
@@ -266,31 +279,37 @@ export function FormularioDomicilioUnificado({
             <Input
               value={domicilio.localidad || ''}
               onChange={(e) => onDomicilioChange('localidad', e.target.value)}
-              placeholder="Localidad"
+              placeholder={status === 'initial' ? 'Se autocompleta con el C.P.' : 'Localidad'}
               className="bg-white border-gray-100 text-gray-900 shadow-sm"
               readOnly={readonly}
             />
           </div>
         )}
 
-        {direccionInfo && direccionInfo.colonias.length > 0 && (
-          <div className="space-y-2">
-            <Label>
-              Colonia *
+        <div className="space-y-2">
+          <Label>
+            Colonia *
+            {direccionInfo && (
               <span className="text-sm text-muted-foreground ml-2">
                 ({direccionInfo.colonias.length} disponibles)
               </span>
-            </Label>
-            
-            <Select value={coloniaSeleccionada} onValueChange={handleColoniaChange} disabled={readonly}>
-              <SelectTrigger className="bg-white border-gray-100 text-gray-900 focus:border-gray-400 focus:ring-gray-400/10 shadow-sm">
-                <SelectValue placeholder="Selecciona una colonia" />
-              </SelectTrigger>
+            )}
+          </Label>
+
+          <Select
+            value={coloniaSeleccionada}
+            onValueChange={handleColoniaChange}
+            disabled={readonly || !direccionInfo}
+          >
+            <SelectTrigger className="bg-white border-gray-100 text-gray-900 focus:border-gray-400 focus:ring-gray-400/10 shadow-sm">
+              <SelectValue placeholder={direccionInfo ? 'Selecciona una colonia' : 'Se autocompleta con el C.P.'} />
+            </SelectTrigger>
+            {direccionInfo && (
               <SelectContent className="bg-background border shadow-lg z-50 max-h-60">
                 {direccionInfo.colonias.map((coloniaObj, index) => (
-                  <SelectItem 
-                    key={`${coloniaObj.nombre}-${index}`} 
-                    value={coloniaObj.nombre} 
+                  <SelectItem
+                    key={`${coloniaObj.nombre}-${index}`}
+                    value={coloniaObj.nombre}
                     className="cursor-pointer hover:bg-accent"
                   >
                     <div className="flex flex-col">
@@ -304,9 +323,9 @@ export function FormularioDomicilioUnificado({
                   </SelectItem>
                 ))}
               </SelectContent>
-            </Select>
-          </div>
-        )}
+            )}
+          </Select>
+        </div>
       </div>
 
       {/* Calle y Números */}


### PR DESCRIPTION
## Summary
- improve placeholder and loading state messaging in `FormularioDomicilioUnificado`
- remove gray disabled look and keep fields readonly in `SmartUbicacionFormV2`
- apply same placeholders in DatosFiscalesForm

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any and other existing issues)*

------
https://chatgpt.com/codex/tasks/task_e_685a1d1ada14832bb3bc5d2544637f30