### PR TITLE
Add draft save flow for ViajeWizard

### DIFF
--- a/src/components/viajes/ViajeWizardModal.tsx
+++ b/src/components/viajes/ViajeWizardModal.tsx
@@ -1,14 +1,27 @@
 
 import { ResponsiveDialog, ResponsiveDialogContent } from '@/components/ui/responsive-dialog'
 import { DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog'
-import { ViajeWizard } from './ViajeWizard'
+import { ViajeWizard, ViajeWizardHandle } from './ViajeWizard'
 import { useViajeWizardModal } from '@/contexts/ViajeWizardModalProvider'
+
+import { useRef } from 'react'
 
 export function ViajeWizardModal() {
   const { isViajeWizardOpen, closeViajeWizard } = useViajeWizardModal()
+  const wizardRef = useRef<ViajeWizardHandle>(null)
+
+  const handleOpenChange = (open: boolean) => {
+    if (!open) {
+      if (wizardRef.current) {
+        wizardRef.current.requestClose()
+      } else {
+        closeViajeWizard()
+      }
+    }
+  }
 
   return (
-    <ResponsiveDialog open={isViajeWizardOpen} onOpenChange={(open) => { if(!open) closeViajeWizard() }}>
+    <ResponsiveDialog open={isViajeWizardOpen} onOpenChange={handleOpenChange}>
       <ResponsiveDialogContent className="focus:outline-none">
         <DialogHeader className="sr-only">
           <DialogTitle>Programar Nuevo Viaje</DialogTitle>
@@ -17,7 +30,7 @@ export function ViajeWizardModal() {
           </DialogDescription>
         </DialogHeader>
         <div className="w-full h-full">
-          <ViajeWizard onCancel={closeViajeWizard} onComplete={closeViajeWizard} />
+          <ViajeWizard ref={wizardRef} onCancel={closeViajeWizard} onComplete={closeViajeWizard} />
         </div>
       </ResponsiveDialogContent>
     </ResponsiveDialog>


### PR DESCRIPTION
## Summary
- enable saving viaje drafts via `useViajes`
- intercept modal close to warn about unsaved changes
- add draft buttons and confirmation dialog in ViajeWizard

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685a33aa1168832b9704155b5ef96dcb