### PR TITLE
Implement action menu for viajes cards

### DIFF
--- a/src/hooks/useViajes.ts
+++ b/src/hooks/useViajes.ts
@@ -218,6 +218,47 @@ export const useViajes = () => {
     }
   });
 
+  // Cancelar viaje
+  const cancelarViaje = useMutation({
+    mutationFn: async (id: string) => {
+      const { data, error } = await supabase
+        .from('viajes')
+        .update({ estado: 'cancelado' })
+        .eq('id', id)
+        .select()
+        .single();
+
+      if (error) throw error;
+      return data as Viaje;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['viajes'] });
+      toast.success('Viaje cancelado');
+    },
+    onError: () => {
+      toast.error('Error al cancelar el viaje');
+    }
+  });
+
+  // Eliminar viaje
+  const eliminarViaje = useMutation({
+    mutationFn: async (id: string) => {
+      const { error } = await supabase
+        .from('viajes')
+        .delete()
+        .eq('id', id);
+      if (error) throw error;
+      return id;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['viajes'] });
+      toast.success('Viaje eliminado');
+    },
+    onError: () => {
+      toast.error('Error al eliminar el viaje');
+    }
+  });
+
   // Guardar borrador de viaje
   const guardarBorradorViaje = useMutation({
     mutationFn: async ({ wizardData, borradorId }: { wizardData: ViajeWizardData; borradorId?: string }) => {
@@ -278,6 +319,8 @@ export const useViajes = () => {
     isCreatingViaje: isCreatingViaje || crearViaje.isPending,
     actualizarViaje: actualizarViaje.mutate,
     isUpdatingViaje: actualizarViaje.isPending,
+    cancelarViaje: cancelarViaje.mutate,
+    eliminarViaje: eliminarViaje.mutate,
     guardarBorradorViaje: guardarBorradorViaje.mutateAsync,
     isSavingDraft: guardarBorradorViaje.isPending
   };


### PR DESCRIPTION
## Summary
- add cancelarViaje and eliminarViaje mutations
- expose the new actions in the hook API
- implement dropdown action menu on viaje cards
- add confirmation dialogs for cancel and delete operations

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: could not install vitest)*

------
https://chatgpt.com/codex/tasks/task_e_685a36a8979c832b8548b71dfce9f722