### PR TITLE
Organize sidebar menu by categories

### DIFF
--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -23,24 +23,82 @@ import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip
 import { useUnifiedPermissionsV2 } from '@/hooks/useUnifiedPermissionsV2';
 import { useIsMobile } from '@/hooks/use-mobile';
 
+export type SidebarCategory =
+  | 'OPERACIÓN'
+  | 'RECURSOS'
+  | 'ADMINISTRACIÓN FISCAL'
+  | 'CUENTA Y CONFIGURACIÓN';
+
 interface SidebarItem {
   title: string;
   href: string;
   icon: any;
   badge?: string;
   requiresPermission?: boolean;
+  category: SidebarCategory;
 }
 
 const sidebarItems: SidebarItem[] = [
-  { title: 'Dashboard', href: '/dashboard', icon: LayoutDashboard },
-  { title: 'Viajes', href: '/viajes', icon: Route, requiresPermission: true },
-  { title: 'Vehículos', href: '/vehiculos', icon: Car, requiresPermission: true },
-  { title: 'Conductores', href: '/conductores', icon: Users, requiresPermission: true },
-  { title: 'Socios', href: '/socios', icon: Building2, requiresPermission: true },
-  { title: 'Remolques', href: '/remolques', icon: Wrench, requiresPermission: true },
-  { title: 'Carta Porte', href: '/cartas-porte', icon: FileText, requiresPermission: true },
-  { title: 'Planes', href: '/planes', icon: CreditCard },
-  { title: 'Configuración', href: '/configuracion/empresa', icon: Settings }
+  {
+    title: 'Dashboard',
+    href: '/dashboard',
+    icon: LayoutDashboard,
+    category: 'OPERACIÓN',
+  },
+  {
+    title: 'Viajes',
+    href: '/viajes',
+    icon: Route,
+    requiresPermission: true,
+    category: 'OPERACIÓN',
+  },
+  {
+    title: 'Vehículos',
+    href: '/vehiculos',
+    icon: Car,
+    requiresPermission: true,
+    category: 'RECURSOS',
+  },
+  {
+    title: 'Conductores',
+    href: '/conductores',
+    icon: Users,
+    requiresPermission: true,
+    category: 'RECURSOS',
+  },
+  {
+    title: 'Socios',
+    href: '/socios',
+    icon: Building2,
+    requiresPermission: true,
+    category: 'RECURSOS',
+  },
+  {
+    title: 'Remolques',
+    href: '/remolques',
+    icon: Wrench,
+    requiresPermission: true,
+    category: 'RECURSOS',
+  },
+  {
+    title: 'Carta Porte',
+    href: '/cartas-porte',
+    icon: FileText,
+    requiresPermission: true,
+    category: 'ADMINISTRACIÓN FISCAL',
+  },
+  {
+    title: 'Planes',
+    href: '/planes',
+    icon: CreditCard,
+    category: 'CUENTA Y CONFIGURACIÓN',
+  },
+  {
+    title: 'Mi Empresa',
+    href: '/configuracion/empresa',
+    icon: Building2,
+    category: 'CUENTA Y CONFIGURACIÓN',
+  },
 ];
 
 interface AppSidebarProps {
@@ -118,44 +176,61 @@ export function AppSidebar({ isMobileOpen = false, setIsMobileOpen }: AppSidebar
       </div>
 
       <nav className="flex-1 px-2 space-y-2">
-        {sidebarItems.map((item) => {
-          const isActive = location.pathname.startsWith(item.href);
-          const canAccess = canAccessItem(item);
-          const badge = getItemBadge(item);
-          const Icon = item.icon;
+        {Object.entries(
+          sidebarItems.reduce<Record<SidebarCategory, SidebarItem[]>>((acc, item) => {
+            if (!acc[item.category]) acc[item.category] = [];
+            acc[item.category].push(item);
+            return acc;
+          }, {} as Record<SidebarCategory, SidebarItem[]>)
+        ).map(([category, items], index) => (
+          <div key={category} className="space-y-2">
+            {!isCollapsed && (
+              <span
+                className="block px-3 mt-6 first:mt-0 text-xs font-semibold text-gray-400 uppercase"
+              >
+                {category}
+              </span>
+            )}
+            {items.map((item) => {
+              const isActive = location.pathname.startsWith(item.href);
+              const canAccess = canAccessItem(item);
+              const badge = getItemBadge(item);
+              const Icon = item.icon;
 
-          const linkClasses = `
-            flex items-center justify-between px-3 py-2 rounded-lg text-sm font-medium transition-colors
-            ${isActive
-              ? 'bg-blue-50 text-blue-700'
-              : canAccess
-                ? 'text-gray-700 hover:bg-gray-50 hover:text-gray-900'
-                : 'text-gray-400 cursor-not-allowed'}
-          `;
+              const linkClasses = `
+                flex items-center justify-between px-3 py-2 rounded-lg text-sm font-medium transition-colors
+                ${isActive
+                  ? 'bg-blue-50 text-blue-700'
+                  : canAccess
+                    ? 'text-gray-700 hover:bg-gray-50 hover:text-gray-900'
+                    : 'text-gray-400 cursor-not-allowed'}
+              `;
 
-          return (
-            <Tooltip key={item.href}>
-              <TooltipTrigger asChild>
-                <Link to={item.href} className={linkClasses}>
-                  <div className="flex items-center space-x-3">
-                    <Icon className="h-5 w-5" />
-                    {!isCollapsed && <span>{item.title}</span>}
-                  </div>
-                  {badge && !isCollapsed && (
-                    <Badge variant="outline" className="text-xs">
-                      {badge}
-                    </Badge>
+              return (
+                <Tooltip key={item.href}>
+                  <TooltipTrigger asChild>
+                    <Link to={item.href} className={linkClasses}>
+                      <div className="flex items-center space-x-3">
+                        <Icon className="h-5 w-5" />
+                        {!isCollapsed && <span>{item.title}</span>}
+                      </div>
+                      {badge && !isCollapsed && (
+                        <Badge variant="outline" className="text-xs">
+                          {badge}
+                        </Badge>
+                      )}
+                    </Link>
+                  </TooltipTrigger>
+                  {isCollapsed && (
+                    <TooltipContent side="right" className="capitalize">
+                      {item.title}
+                    </TooltipContent>
                   )}
-                </Link>
-              </TooltipTrigger>
-              {isCollapsed && (
-                <TooltipContent side="right" className="capitalize">
-                  {item.title}
-                </TooltipContent>
-              )}
-            </Tooltip>
-          );
-        })}
+                </Tooltip>
+              );
+            })}
+          </div>
+        ))}
       </nav>
 
       <div className="p-4 border-t border-gray-200 space-y-3">

--- a/src/nav-items.tsx
+++ b/src/nav-items.tsx
@@ -1,7 +1,7 @@
 
-import { 
-  HomeIcon, 
-  FileTextIcon, 
+import {
+  HomeIcon,
+  FileTextIcon,
   SettingsIcon,
   LayoutDashboard,
   Car,
@@ -9,7 +9,8 @@ import {
   Building2,
   Truck,
   CreditCard,
-  AlertTriangle
+  AlertTriangle,
+  Wrench
 } from "lucide-react";
 
 import Index from "./pages/Index";
@@ -20,6 +21,7 @@ import Vehiculos from "./pages/Vehiculos";
 import Conductores from "./pages/Conductores";
 import Socios from "./pages/Socios";
 import Viajes from "./pages/Viajes";
+import Remolques from "./pages/Remolques";
 import Administracion from "./pages/Administracion";
 import Planes from "./pages/Planes";
 import ConfiguracionEmpresa from "./pages/ConfiguracionEmpresa";
@@ -32,25 +34,44 @@ import DebugPermissionsTest from "./pages/DebugPermissionsTest";
  * - /cartas-porte = Gestión y listado de documentos
  * - /carta-porte/editor = Editor completo con todos los módulos (ubicaciones, mercancías, figuras, etc.)
  */
-export const navItems = [
+export type NavCategory =
+  | "OPERACIÓN"
+  | "RECURSOS"
+  | "ADMINISTRACIÓN FISCAL"
+  | "CUENTA Y CONFIGURACIÓN";
+
+export interface NavItem {
+  title: string;
+  to: string;
+  icon: JSX.Element;
+  page: JSX.Element;
+  description?: string;
+  hideFromNav?: boolean;
+  category: NavCategory;
+}
+
+export const navItems: NavItem[] = [
   {
     title: "Inicio",
     to: "/",
     icon: <HomeIcon className="h-4 w-4" />,
     page: <Index />,
+    category: "OPERACIÓN",
   },
   {
-    title: "Dashboard", 
+    title: "Dashboard",
     to: "/dashboard",
     icon: <LayoutDashboard className="h-4 w-4" />,
     page: <Dashboard />,
+    category: "OPERACIÓN",
   },
   {
     title: "Cartas Porte",
     to: "/cartas-porte",
     icon: <FileTextIcon className="h-4 w-4" />,
     page: <CartasPorteUnified />,
-    description: "Gestión y listado de documentos de Carta Porte"
+    description: "Gestión y listado de documentos de Carta Porte",
+    category: "ADMINISTRACIÓN FISCAL",
   },
   {
     title: "Editor Carta Porte",
@@ -58,37 +79,51 @@ export const navItems = [
     icon: <FileTextIcon className="h-4 w-4" />,
     page: <CartaPorteEditor />,
     hideFromNav: true,
-    description: "Editor completo con módulos: ubicaciones, mercancías, figuras, autotransporte"
+    description: "Editor completo con módulos: ubicaciones, mercancías, figuras, autotransporte",
+    category: "ADMINISTRACIÓN FISCAL",
   },
   {
     title: "Vehículos",
     to: "/vehiculos",
     icon: <Car className="h-4 w-4" />,
     page: <Vehiculos />,
+    category: "RECURSOS",
   },
   {
     title: "Conductores",
     to: "/conductores",
     icon: <Users className="h-4 w-4" />,
     page: <Conductores />,
+    category: "RECURSOS",
   },
   {
     title: "Socios",
     to: "/socios",
     icon: <Building2 className="h-4 w-4" />,
     page: <Socios />,
+    category: "RECURSOS",
+  },
+  {
+    title: "Remolques",
+    to: "/remolques",
+    icon: <Wrench className="h-4 w-4" />,
+    page: <Remolques />,
+    hideFromNav: true,
+    category: "RECURSOS",
   },
   {
     title: "Viajes",
     to: "/viajes",
     icon: <Truck className="h-4 w-4" />,
     page: <Viajes />,
+    category: "OPERACIÓN",
   },
   {
     title: "Administración",
     to: "/administracion",
     icon: <SettingsIcon className="h-4 w-4" />,
     page: <Administracion />,
+    category: "CUENTA Y CONFIGURACIÓN",
   },
   {
     title: "Mi Empresa",
@@ -96,13 +131,15 @@ export const navItems = [
     icon: <Building2 className="h-4 w-4" />,
     page: <ConfiguracionEmpresa />,
     hideFromNav: true,
-    description: "Configuración de datos fiscales y certificados digitales"
+    description: "Configuración de datos fiscales y certificados digitales",
+    category: "CUENTA Y CONFIGURACIÓN",
   },
   {
     title: "Planes",
     to: "/planes",
     icon: <CreditCard className="h-4 w-4" />,
     page: <Planes />,
+    category: "CUENTA Y CONFIGURACIÓN",
   },
   {
     title: "Debug: Permisos V2",
@@ -110,6 +147,7 @@ export const navItems = [
     icon: <AlertTriangle className="h-4 w-4" />,
     page: <DebugPermissionsTest />,
     hideFromNav: true,
-    description: "Página de validación para el nuevo sistema de permisos"
+    description: "Página de validación para el nuevo sistema de permisos",
+    category: "OPERACIÓN",
   },
 ];


### PR DESCRIPTION
## Summary
- add category support to nav items
- group links in the AppSidebar by category and style section headers

## Testing
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_685a37d49a60832bbf1f385f7483adbe