### PR TITLE
Implement Calendario page with Google Calendar integration

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,7 @@ import Remolques from "./pages/Remolques"
 import Administracion from "./pages/Administracion"
 import Planes from "./pages/Planes"
 import ConfiguracionEmpresa from "./pages/ConfiguracionEmpresa"
+import Calendario from "./pages/Calendario"
 
 // Nuevos componentes
 import { ViajeWizard } from "./components/viajes/ViajeWizard"
@@ -103,6 +104,14 @@ const App = () => (
                 <AuthGuard>
                   <BaseLayout>
                     <Viajes />
+                  </BaseLayout>
+                </AuthGuard>
+              } />
+
+              <Route path="/calendario" element={
+                <AuthGuard>
+                  <BaseLayout>
+                    <Calendario />
                   </BaseLayout>
                 </AuthGuard>
               } />

--- a/src/hooks/useOperacionesEventos.ts
+++ b/src/hooks/useOperacionesEventos.ts
@@ -1,0 +1,29 @@
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import { useAuth } from './useAuth';
+
+export interface OperacionEvento {
+  id: string;
+  tipo: string;
+  titulo: string;
+  fecha_inicio: string;
+  fecha_fin?: string;
+  metadata?: any;
+}
+
+export function useOperacionesEventos() {
+  const { user } = useAuth();
+
+  const { data: eventos = [], isLoading } = useQuery({
+    queryKey: ['operaciones-eventos', user?.id],
+    queryFn: async () => {
+      if (!user?.id) return [];
+      const { data, error } = await supabase.functions.invoke('operaciones-eventos');
+      if (error) throw error;
+      return (data?.events || []) as OperacionEvento[];
+    },
+    enabled: !!user?.id,
+  });
+
+  return { eventos, isLoading };
+}

--- a/src/nav-items.tsx
+++ b/src/nav-items.tsx
@@ -10,7 +10,8 @@ import {
   Truck,
   CreditCard,
   AlertTriangle,
-  Wrench
+  Wrench,
+  Calendar as CalendarIcon
 } from "lucide-react";
 
 import Index from "./pages/Index";
@@ -26,6 +27,7 @@ import Administracion from "./pages/Administracion";
 import Planes from "./pages/Planes";
 import ConfiguracionEmpresa from "./pages/ConfiguracionEmpresa";
 import DebugPermissionsTest from "./pages/DebugPermissionsTest";
+import Calendario from "./pages/Calendario";
 
 /**
  * Central place for defining the navigation items. Used for navigation components and routing.
@@ -116,6 +118,13 @@ export const navItems: NavItem[] = [
     to: "/viajes",
     icon: <Truck className="h-4 w-4" />,
     page: <Viajes />,
+    category: "OPERACIÓN",
+  },
+  {
+    title: "Calendario",
+    to: "/calendario",
+    icon: <CalendarIcon className="h-4 w-4" />,
+    page: <Calendario />,
     category: "OPERACIÓN",
   },
   {

--- a/src/pages/Calendario.tsx
+++ b/src/pages/Calendario.tsx
@@ -1,0 +1,53 @@
+import { useState } from 'react';
+import { ProtectedContent } from '@/components/ProtectedContent';
+import { EnhancedCalendarView } from '@/components/dashboard/EnhancedCalendarView';
+import { Checkbox } from '@/components/ui/checkbox';
+
+export default function Calendario() {
+  const [showViajes, setShowViajes] = useState(true);
+  const [showMantenimientos, setShowMantenimientos] = useState(true);
+
+  return (
+    <ProtectedContent requiredFeature="calendario">
+      <div className="p-4 md:p-6">
+        <div className="flex flex-col md:flex-row gap-6">
+          <aside className="w-full md:w-64 space-y-4">
+            <h2 className="font-semibold">Mis Calendarios</h2>
+            <div className="space-y-2">
+              <div className="flex items-center space-x-2">
+                <Checkbox id="viajes" checked={showViajes} onCheckedChange={setShowViajes} />
+                <label htmlFor="viajes" className="text-sm">Viajes Programados</label>
+              </div>
+              <div className="flex items-center space-x-2">
+                <Checkbox id="mantenimientos" checked={showMantenimientos} onCheckedChange={setShowMantenimientos} />
+                <label htmlFor="mantenimientos" className="text-sm">Mantenimientos</label>
+              </div>
+            </div>
+          </aside>
+          <div className="flex-1">
+            <div className="flex justify-end mb-4">
+              <GoogleConnectButton />
+            </div>
+            <EnhancedCalendarView />
+          </div>
+        </div>
+      </div>
+    </ProtectedContent>
+  );
+}
+
+function GoogleConnectButton() {
+  const handleConnect = () => {
+    const clientId = import.meta.env.VITE_GOOGLE_CLIENT_ID;
+    const redirectUri = `${window.location.origin}/google/callback`;
+    const scope = 'https://www.googleapis.com/auth/calendar.events';
+    const url = `https://accounts.google.com/o/oauth2/v2/auth?client_id=${clientId}&redirect_uri=${encodeURIComponent(redirectUri)}&response_type=code&scope=${encodeURIComponent(scope)}&access_type=offline&prompt=consent`;
+    window.location.href = url;
+  };
+
+  return (
+    <button onClick={handleConnect} className="bg-blue-600 text-white px-3 py-1 rounded text-sm">
+      Conectar con Google Calendar
+    </button>
+  );
+}

--- a/src/services/google/GoogleCalendarSyncService.ts
+++ b/src/services/google/GoogleCalendarSyncService.ts
@@ -1,0 +1,21 @@
+import { supabase } from '@/integrations/supabase/client';
+
+class GoogleCalendarSyncService {
+  async exchangeCode(code: string) {
+    const { data, error } = await supabase.functions.invoke('google-oauth-callback', {
+      body: { code },
+    });
+    if (error) throw error;
+    return data;
+  }
+
+  async pushEvent(userId: string, event: Record<string, any>) {
+    const { data, error } = await supabase.functions.invoke('google-calendar-sync', {
+      body: { userId, event },
+    });
+    if (error) throw error;
+    return data;
+  }
+}
+
+export const googleCalendarSyncService = new GoogleCalendarSyncService();

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -5,6 +5,7 @@
 interface ImportMetaEnv {
   readonly VITE_SUPABASE_URL: string
   readonly VITE_SUPABASE_ANON_KEY: string
+  readonly VITE_GOOGLE_CLIENT_ID?: string
 }
 
 interface ImportMeta {

--- a/supabase/functions/google-oauth-callback/index.ts
+++ b/supabase/functions/google-oauth-callback/index.ts
@@ -1,0 +1,69 @@
+import { serve } from 'https://deno.land/std@0.190.0/http/server.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { corsHeaders } from '../_shared/cors.ts';
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  const supabase = createClient(
+    Deno.env.get('SUPABASE_URL') ?? '',
+    Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
+  );
+
+  try {
+    if (req.method !== 'POST') {
+      return new Response(JSON.stringify({ error: 'Método no permitido' }), {
+        status: 405,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    const { code, redirectUri, userId } = await req.json();
+    if (!code || !userId) {
+      return new Response(JSON.stringify({ error: 'Datos incompletos' }), {
+        status: 400,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    const params = new URLSearchParams({
+      code,
+      client_id: Deno.env.get('GOOGLE_CLIENT_ID') ?? '',
+      client_secret: Deno.env.get('GOOGLE_CLIENT_SECRET') ?? '',
+      redirect_uri: redirectUri ?? '',
+      grant_type: 'authorization_code',
+    });
+
+    const tokenRes = await fetch('https://oauth2.googleapis.com/token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: params.toString(),
+    });
+
+    if (!tokenRes.ok) {
+      const text = await tokenRes.text();
+      throw new Error(`Token exchange failed: ${text}`);
+    }
+
+    const tokens = await tokenRes.json();
+
+    const { error: updateError } = await supabase
+      .from('profiles')
+      .update({ configuracion_calendario: tokens })
+      .eq('id', userId);
+
+    if (updateError) throw updateError;
+
+    return new Response(JSON.stringify({ success: true }), {
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  } catch (err) {
+    console.error('google-oauth-callback error:', err);
+    return new Response(JSON.stringify({ error: err.message }), {
+      status: 500,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  }
+});

--- a/supabase/functions/operaciones-eventos/index.ts
+++ b/supabase/functions/operaciones-eventos/index.ts
@@ -1,0 +1,81 @@
+import { serve } from 'https://deno.land/std@0.190.0/http/server.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { corsHeaders } from '../_shared/cors.ts';
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  const supabase = createClient(
+    Deno.env.get('SUPABASE_URL') ?? '',
+    Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
+  );
+
+  try {
+    const auth = req.headers.get('Authorization');
+    if (!auth) {
+      return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+        status: 401,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    const token = auth.replace('Bearer ', '');
+    const { data: { user }, error: userError } = await supabase.auth.getUser(token);
+    if (userError || !user) {
+      return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+        status: 401,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    const { data: viajes, error: viajesError } = await supabase
+      .from('viajes')
+      .select('id, origen, destino, estado, fecha_inicio_programada, fecha_fin_programada')
+      .eq('user_id', user.id);
+
+    if (viajesError) throw viajesError;
+
+    const { data: programaciones, error: progError } = await supabase
+      .from('programaciones')
+      .select('*')
+      .eq('user_id', user.id);
+
+    if (progError) throw progError;
+
+    const events: any[] = [];
+
+    for (const v of viajes ?? []) {
+      events.push({
+        id: `viaje-${v.id}`,
+        tipo: 'viaje',
+        titulo: `Viaje ${v.origen} - ${v.destino}`,
+        fecha_inicio: v.fecha_inicio_programada,
+        fecha_fin: v.fecha_fin_programada,
+        metadata: { estado: v.estado },
+      });
+    }
+
+    for (const p of programaciones ?? []) {
+      events.push({
+        id: `prog-${p.id}`,
+        tipo: p.tipo_programacion,
+        titulo: p.descripcion,
+        fecha_inicio: p.fecha_inicio,
+        fecha_fin: p.fecha_fin,
+        metadata: { entidad: p.entidad_tipo, estado: p.estado },
+      });
+    }
+
+    return new Response(JSON.stringify({ events, success: true }), {
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  } catch (err) {
+    console.error('operaciones-eventos error:', err);
+    return new Response(JSON.stringify({ error: err.message }), {
+      status: 500,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- add a new `Calendario` page with filter panel and Google connect button
- register Calendario in router and navigation items
- expose hook `useOperacionesEventos` to load events from backend
- create GoogleCalendarSyncService utility
- add edge functions for retrieving operations events and OAuth callback
- update environment types with `VITE_GOOGLE_CLIENT_ID`

## Testing
- `npm run lint` *(fails: cannot find jsdom and many lint errors)*
- `npx vitest run` *(fails: missing jsdom and coverage dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685ab9b5bf3c832bafc6c2c11bcc1b61