### PR TITLE
Add detailed operations calendar

### DIFF
--- a/src/components/calendar/OperationsCalendar.tsx
+++ b/src/components/calendar/OperationsCalendar.tsx
@@ -9,12 +9,23 @@ import { CalendarEvent } from '@/hooks/useCalendarEvents';
 moment.locale('es');
 const localizer = momentLocalizer(moment);
 
-export function OperationsCalendar() {
+interface OperationsCalendarProps {
+  showViajes: boolean;
+  showMantenimientos: boolean;
+}
+
+export function OperationsCalendar({ showViajes, showMantenimientos }: OperationsCalendarProps) {
   const { eventos, isLoading } = useOperacionesEventos();
   const [selected, setSelected] = useState<CalendarEvent | null>(null);
   const [open, setOpen] = useState(false);
 
-  const calendarEvents: CalendarEvent[] = eventos.map(ev => ({
+  const filtered = eventos.filter((ev) => {
+    if (ev.tipo === 'viaje' && !showViajes) return false;
+    if (ev.tipo === 'mantenimiento' && !showMantenimientos) return false;
+    return true;
+  });
+
+  const calendarEvents: CalendarEvent[] = filtered.map((ev) => ({
     id: ev.id,
     titulo: ev.titulo,
     tipo_evento: ev.tipo,
@@ -24,11 +35,12 @@ export function OperationsCalendar() {
     metadata: ev.metadata,
   }));
 
-  const rbcEvents = calendarEvents.map(ev => ({
+  const rbcEvents = calendarEvents.map((ev) => ({
     id: ev.id,
     title: ev.titulo,
     start: ev.fecha_inicio,
     end: ev.fecha_fin!,
+    allDay: ev.metadata?.todo_dia ?? false,
     resource: {
       tipo_evento: ev.tipo_evento,
       descripcion: ev.descripcion,

--- a/src/components/dashboard/TripDetailModal.tsx
+++ b/src/components/dashboard/TripDetailModal.tsx
@@ -84,6 +84,28 @@ export function TripDetailModal({ event, open, onOpenChange }: TripDetailModalPr
             </Badge>
           </div>
 
+          {(event.resource.metadata?.estado || event.resource.metadata?.vehiculo || event.resource.metadata?.conductor) && (
+            <Card>
+              <CardContent className="pt-4 space-y-2">
+                {event.resource.metadata?.estado && (
+                  <Badge variant="outline" className="capitalize">
+                    {event.resource.metadata.estado}
+                  </Badge>
+                )}
+                {(event.resource.metadata?.vehiculo || event.resource.metadata?.conductor) && (
+                  <div className="text-sm text-muted-foreground space-y-1">
+                    {event.resource.metadata?.vehiculo && (
+                      <p>Vehículo: {event.resource.metadata.vehiculo}</p>
+                    )}
+                    {event.resource.metadata?.conductor && (
+                      <p>Conductor: {event.resource.metadata.conductor}</p>
+                    )}
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          )}
+
           {/* Fechas y horarios */}
           <Card>
             <CardContent className="pt-4">
@@ -189,6 +211,15 @@ export function TripDetailModal({ event, open, onOpenChange }: TripDetailModalPr
               </div>
             </CardContent>
           </Card>
+
+          <div className="flex justify-end">
+            <a
+              href="/viajes"
+              className="mt-2 inline-flex items-center px-3 py-1.5 text-sm font-medium bg-blue-600 text-white rounded"
+            >
+              Ver Detalles del Viaje
+            </a>
+          </div>
         </div>
       </DialogContent>
     </Dialog>

--- a/src/hooks/useOperacionesEventos.ts
+++ b/src/hooks/useOperacionesEventos.ts
@@ -8,7 +8,15 @@ export interface OperacionEvento {
   titulo: string;
   fecha_inicio: string;
   fecha_fin?: string;
-  metadata?: any;
+  metadata?: {
+    estado?: string;
+    carta_porte_id?: string;
+    vehiculo?: string | null;
+    conductor?: string | null;
+    entidad?: string;
+    todo_dia?: boolean;
+    [key: string]: any;
+  };
 }
 
 export function useOperacionesEventos() {

--- a/src/pages/Calendario.tsx
+++ b/src/pages/Calendario.tsx
@@ -28,7 +28,10 @@ export default function Calendario() {
             <div className="flex justify-end mb-4">
               <GoogleConnectButton />
             </div>
-            <OperationsCalendar />
+            <OperationsCalendar
+              showViajes={showViajes}
+              showMantenimientos={showMantenimientos}
+            />
           </div>
         </div>
       </div>

--- a/supabase/functions/operaciones-eventos/index.ts
+++ b/supabase/functions/operaciones-eventos/index.ts
@@ -32,7 +32,12 @@ serve(async (req) => {
 
     const { data: viajes, error: viajesError } = await supabase
       .from('viajes')
-      .select('id, origen, destino, estado, fecha_inicio_programada, fecha_fin_programada')
+      .select(
+        `id, origen, destino, estado, carta_porte_id,
+         fecha_inicio_programada, fecha_fin_programada,
+         vehiculo:vehiculos(id, placa),
+         conductor:conductores(id, nombre)`
+      )
       .eq('user_id', user.id);
 
     if (viajesError) throw viajesError;
@@ -50,10 +55,15 @@ serve(async (req) => {
       events.push({
         id: `viaje-${v.id}`,
         tipo: 'viaje',
-        titulo: `Viaje ${v.origen} - ${v.destino}`,
+        titulo: `${v.carta_porte_id} ${v.origen}→${v.destino}`,
         fecha_inicio: v.fecha_inicio_programada,
         fecha_fin: v.fecha_fin_programada,
-        metadata: { estado: v.estado },
+        metadata: {
+          estado: v.estado,
+          carta_porte_id: v.carta_porte_id,
+          vehiculo: v.vehiculo?.placa ?? null,
+          conductor: v.conductor?.nombre ?? null,
+        },
       });
     }
 
@@ -64,7 +74,11 @@ serve(async (req) => {
         titulo: p.descripcion,
         fecha_inicio: p.fecha_inicio,
         fecha_fin: p.fecha_fin,
-        metadata: { entidad: p.entidad_tipo, estado: p.estado },
+        metadata: {
+          entidad: p.entidad_tipo,
+          estado: p.estado,
+          todo_dia: true,
+        },
       });
     }
 


### PR DESCRIPTION
## Summary
- enrich `operaciones-eventos` function to include vehicle and driver info
- extend event metadata types to handle new fields
- filter calendar events and mark all-day events
- enhance calendar modal with state, resources and link to trips
- wire filtering options on `Calendario` page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ac56e7130832bb55ef0d01cfb2f00