### PR TITLE
Optimize hero asset loading

### DIFF
--- a/src/components/carta-porte/xml/sections/TimbradoSection.tsx
+++ b/src/components/carta-porte/xml/sections/TimbradoSection.tsx
@@ -159,10 +159,11 @@ export function TimbradoSection({
                   <strong>Código QR Fiscal:</strong>
                 </div>
                 <div className="flex justify-center">
-                  <img 
-                    src={datosTimbre.qrCode} 
-                    alt="Código QR Fiscal" 
-                    className="w-32 h-32 border border-gray-300 rounded" 
+                  <img
+                    src={datosTimbre.qrCode}
+                    alt="Código QR Fiscal"
+                    className="w-32 h-32 border border-gray-300 rounded"
+                    loading="lazy"
                   />
                 </div>
               </div>

--- a/src/components/conductores/forms/ConductorBasicFields.tsx
+++ b/src/components/conductores/forms/ConductorBasicFields.tsx
@@ -43,10 +43,11 @@ export function ConductorBasicFields({ formData, onFieldChange, errors }: Conduc
           <div className="flex items-center gap-4">
             {formData.foto_preview ? (
               <div className="relative">
-                <img 
-                  src={formData.foto_preview} 
-                  alt="Foto del conductor" 
+                <img
+                  src={formData.foto_preview}
+                  alt="Foto del conductor"
                   className="w-20 h-20 rounded-full object-cover border-2 border-gray-200"
+                  loading="lazy"
                 />
                 <Button
                   type="button"


### PR DESCRIPTION
## Summary
- preload the dashboard hero image for faster LCP
- display hero using `<picture>` element
- lazy load non-critical images
- add `@eslint/js` so ESLint can run

## Testing
- `npm run lint` *(fails: 892 errors)*

------
https://chatgpt.com/codex/tasks/task_e_685afb4dde84832ba84cbd6f15008049