### PR TITLE
Add quick menu for event creation

### DIFF
--- a/src/components/calendar/OperationsCalendar.tsx
+++ b/src/components/calendar/OperationsCalendar.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import FullCalendar, {
   type EventClickArg,
   type EventInput,
+  type DateClickArg,
 } from '@fullcalendar/react';
 import dayGridPlugin from '@fullcalendar/daygrid';
 import timeGridPlugin from '@fullcalendar/timegrid';
@@ -11,6 +12,17 @@ import esLocale from '@fullcalendar/core/locales/es';
 import { useOperacionesEventos } from '@/hooks/useOperacionesEventos';
 import { TripDetailModal } from '@/components/dashboard/TripDetailModal';
 import { CalendarEvent } from '@/hooks/useCalendarEvents';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
+import { Button } from '@/components/ui/button';
+import { Plus, Truck, Wrench, CheckCircle, MapPin } from 'lucide-react';
+import { CartaPorteFormModal } from '@/components/dashboard/CartaPorteFormModal';
+import { MantenimientoFormModal } from '@/components/dashboard/MantenimientoFormModal';
+import { VerificacionFormModal } from '@/components/dashboard/VerificacionFormModal';
+import { RevisionGPSFormModal } from '@/components/dashboard/RevisionGPSFormModal';
 
 
 
@@ -23,6 +35,12 @@ export function OperationsCalendar({ showViajes, showMantenimientos }: Operation
   const { eventos, isLoading } = useOperacionesEventos();
   const [selected, setSelected] = useState<CalendarEvent | null>(null);
   const [open, setOpen] = useState(false);
+  const [selectedDate, setSelectedDate] = useState<Date>();
+  const [showEventMenu, setShowEventMenu] = useState(false);
+  const [showCartaPorteForm, setShowCartaPorteForm] = useState(false);
+  const [showMantenimientoForm, setShowMantenimientoForm] = useState(false);
+  const [showVerificacionForm, setShowVerificacionForm] = useState(false);
+  const [showRevisionGPSForm, setShowRevisionGPSForm] = useState(false);
 
   const filtered = eventos.filter((ev) => {
     if (ev.tipo === 'viaje' && !showViajes) return false;
@@ -66,6 +84,7 @@ export function OperationsCalendar({ showViajes, showMantenimientos }: Operation
     };
   });
 
+
   const handleEventClick = (info: EventClickArg) => {
     const event: CalendarEvent = {
       id: String(info.event.id),
@@ -76,6 +95,31 @@ export function OperationsCalendar({ showViajes, showMantenimientos }: Operation
     };
     setSelected(event);
     setOpen(true);
+  };
+
+  const handleDateClick = (info: DateClickArg) => {
+    setSelectedDate(info.date);
+    setShowEventMenu(true);
+  };
+
+  const handleCreateViaje = () => {
+    setShowCartaPorteForm(true);
+    setShowEventMenu(false);
+  };
+
+  const handleCreateMantenimiento = () => {
+    setShowMantenimientoForm(true);
+    setShowEventMenu(false);
+  };
+
+  const handleCreateVerificacion = () => {
+    setShowVerificacionForm(true);
+    setShowEventMenu(false);
+  };
+
+  const handleCreateRevisionGPS = () => {
+    setShowRevisionGPSForm(true);
+    setShowEventMenu(false);
   };
 
   if (isLoading) {
@@ -97,11 +141,83 @@ export function OperationsCalendar({ showViajes, showMantenimientos }: Operation
           headerToolbar={{ start: 'prev,next today', center: 'title', end: 'dayGridMonth,timeGridWeek,timeGridDay,listWeek' }}
           events={fcEvents}
           eventClick={handleEventClick}
-        />
+          dateClick={handleDateClick}
+          />
       </div>
+      <Popover open={showEventMenu} onOpenChange={setShowEventMenu}>
+        <PopoverTrigger asChild>
+          <div></div>
+        </PopoverTrigger>
+        <PopoverContent className="w-72 z-50" align="center" side="top">
+          <div className="space-y-3">
+            <div className="flex items-center gap-2">
+              <Plus className="h-4 w-4" />
+              <h4 className="font-medium">Crear Evento</h4>
+            </div>
+            <p className="text-sm text-muted-foreground">
+              {selectedDate?.toLocaleDateString('es-ES', {
+                weekday: 'long',
+                year: 'numeric',
+                month: 'long',
+                day: 'numeric',
+              })}
+            </p>
+            <div className="grid grid-cols-1 gap-2">
+              <Button
+                variant="outline"
+                className="w-full justify-start h-9"
+                onClick={handleCreateViaje}
+              >
+                <Truck className="h-4 w-4 mr-2 text-green-600" />
+                Programar Viaje
+              </Button>
+              <Button
+                variant="outline"
+                className="w-full justify-start h-9"
+                onClick={handleCreateMantenimiento}
+              >
+                <Wrench className="h-4 w-4 mr-2 text-red-600" />
+                Mantenimiento
+              </Button>
+              <Button
+                variant="outline"
+                className="w-full justify-start h-9"
+                onClick={handleCreateVerificacion}
+              >
+                <CheckCircle className="h-4 w-4 mr-2 text-orange-600" />
+                Verificación
+              </Button>
+              <Button
+                variant="outline"
+                className="w-full justify-start h-9"
+                onClick={handleCreateRevisionGPS}
+              >
+                <MapPin className="h-4 w-4 mr-2 text-purple-600" />
+                Revisión GPS
+              </Button>
+            </div>
+          </div>
+        </PopoverContent>
+      </Popover>
       {selected && (
         <TripDetailModal event={selected} open={open} onOpenChange={setOpen} />
       )}
+      <CartaPorteFormModal
+        open={showCartaPorteForm}
+        onOpenChange={setShowCartaPorteForm}
+      />
+      <MantenimientoFormModal
+        open={showMantenimientoForm}
+        onOpenChange={setShowMantenimientoForm}
+      />
+      <VerificacionFormModal
+        open={showVerificacionForm}
+        onOpenChange={setShowVerificacionForm}
+      />
+      <RevisionGPSFormModal
+        open={showRevisionGPSForm}
+        onOpenChange={setShowRevisionGPSForm}
+      />
     </>
   );
 }


### PR DESCRIPTION
## Summary
- show a popover menu when clicking a date in `OperationsCalendar`
- allow launching forms for Viaje, Mantenimiento, Verificación and Revisión GPS

## Testing
- `npx -y vitest run` *(fails: Cannot find module 'vite')*

------
https://chatgpt.com/codex/tasks/task_e_685b3794ba70832b8f6951a9ccd529a2