### PR TITLE
Optimize calendar with lazy loading and modal

### DIFF
--- a/src/components/calendar/EventFormModal.tsx
+++ b/src/components/calendar/EventFormModal.tsx
@@ -1,0 +1,85 @@
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+
+const schema = z.object({
+  titulo: z.string().min(1, 'Requerido'),
+  fecha_inicio: z.string(),
+  fecha_fin: z.string(),
+  descripcion: z.string().optional(),
+});
+
+type FormData = z.infer<typeof schema>;
+
+interface EventFormModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  date?: Date | null;
+  onSubmit: (data: { titulo: string; descripcion?: string; fecha_inicio: Date; fecha_fin: Date }) => Promise<void>;
+}
+
+export function EventFormModal({ open, onOpenChange, date, onSubmit }: EventFormModalProps) {
+  const form = useForm<FormData>({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      titulo: '',
+      fecha_inicio: date ? date.toISOString().slice(0,16) : '',
+      fecha_fin: date ? date.toISOString().slice(0,16) : '',
+      descripcion: '',
+    },
+  });
+
+  const handleSubmit = async (values: FormData) => {
+    await onSubmit({
+      titulo: values.titulo,
+      descripcion: values.descripcion,
+      fecha_inicio: new Date(values.fecha_inicio),
+      fecha_fin: new Date(values.fecha_fin),
+    });
+    form.reset();
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[500px]">
+        <DialogHeader>
+          <DialogTitle>Nuevo Evento</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="titulo">Título</Label>
+            <Input id="titulo" {...form.register('titulo')} />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="fecha_inicio">Inicio</Label>
+            <Input id="fecha_inicio" type="datetime-local" {...form.register('fecha_inicio')} />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="fecha_fin">Fin</Label>
+            <Input id="fecha_fin" type="datetime-local" {...form.register('fecha_fin')} />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="descripcion">Descripción</Label>
+            <Textarea id="descripcion" {...form.register('descripcion')} />
+          </div>
+          <div className="flex justify-end gap-2">
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              Cancelar
+            </Button>
+            <Button type="submit">Guardar</Button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/hooks/useOperacionesEventos.ts
+++ b/src/hooks/useOperacionesEventos.ts
@@ -19,18 +19,21 @@ export interface OperacionEvento {
   };
 }
 
-export function useOperacionesEventos() {
+export function useOperacionesEventos(start: Date, end: Date) {
   const { user } = useAuth();
 
   const { data: eventos = [], isLoading } = useQuery({
-    queryKey: ['operaciones-eventos', user?.id],
+    queryKey: ['operaciones-eventos', user?.id, start.toISOString(), end.toISOString()],
     queryFn: async () => {
       if (!user?.id) return [];
-      const { data, error } = await supabase.functions.invoke('operaciones-eventos');
+      const { data, error } = await supabase.functions.invoke('operaciones-eventos', {
+        body: { start_date: start.toISOString(), end_date: end.toISOString() },
+      });
       if (error) throw error;
       return (data?.events || []) as OperacionEvento[];
     },
-    enabled: !!user?.id,
+    enabled: !!user?.id && !!start && !!end,
+    refetchOnWindowFocus: false,
   });
 
   return { eventos, isLoading };

--- a/src/hooks/useUserEvents.ts
+++ b/src/hooks/useUserEvents.ts
@@ -1,0 +1,26 @@
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import { useAuth } from './useAuth';
+
+export const useUserEvents = (start: Date, end: Date) => {
+  const { user } = useAuth();
+
+  return useQuery({
+    queryKey: ['eventos-calendario', user?.id, start.toISOString(), end.toISOString()],
+    queryFn: async () => {
+      if (!user?.id) return [] as any[];
+      const { data, error } = await supabase
+        .from('eventos_calendario')
+        .select('*')
+        .eq('user_id', user.id)
+        .gte('fecha_inicio', start.toISOString())
+        .lte('fecha_inicio', end.toISOString())
+        .order('fecha_inicio', { ascending: true });
+      if (error) throw error;
+      return data || [];
+    },
+    enabled: !!user?.id && !!start && !!end,
+    staleTime: 5 * 60 * 1000,
+    refetchOnWindowFocus: false,
+  });
+};

--- a/src/pages/Calendario.tsx
+++ b/src/pages/Calendario.tsx
@@ -1,10 +1,10 @@
 
-import { useState } from 'react';
+import React, { useState, Suspense } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Label } from '@/components/ui/label';
 import { Calendar, CheckSquare } from 'lucide-react';
-import { OperationsCalendar } from '@/components/calendar/OperationsCalendar';
+const OperationsCalendar = React.lazy(() => import('@/components/calendar/OperationsCalendar'));
 
 export default function Calendario() {
   const [showViajes, setShowViajes] = useState(true);
@@ -61,10 +61,12 @@ export default function Calendario() {
 
       <Card>
         <CardContent className="p-0">
-          <OperationsCalendar 
-            showViajes={showViajes} 
-            showMantenimientos={showMantenimientos} 
-          />
+          <Suspense fallback={<div className="p-4">Cargando calendario...</div>}>
+            <OperationsCalendar
+              showViajes={showViajes}
+              showMantenimientos={showMantenimientos}
+            />
+          </Suspense>
         </CardContent>
       </Card>
     </div>

--- a/supabase/functions/operaciones-eventos/index.ts
+++ b/supabase/functions/operaciones-eventos/index.ts
@@ -39,7 +39,17 @@ serve(async (req) => {
       });
     }
 
-    const { data: viajes, error: viajesError } = await supabase
+    let startDate: string | null = null;
+    let endDate: string | null = null;
+    try {
+      const body = await req.json();
+      startDate = body.start_date ?? null;
+      endDate = body.end_date ?? null;
+    } catch (_) {
+      // ignore empty body
+    }
+
+    const viajesQuery = supabase
       .from('viajes')
       .select(
         `id, origen, destino, estado, carta_porte_id,
@@ -48,15 +58,21 @@ serve(async (req) => {
          conductor:conductores(id, nombre)`
       )
       .eq('user_id', user.id);
+    if (startDate) viajesQuery.gte('fecha_inicio_programada', startDate);
+    if (endDate) viajesQuery.lte('fecha_inicio_programada', endDate);
+    const { data: viajes, error: viajesError } = await viajesQuery;
 
     if (viajesError) throw viajesError;
 
-    const { data: programaciones, error: progError } = await supabase
+    const programacionesQuery = supabase
       .from('programaciones')
       .select(
         'id, tipo_programacion, descripcion, fecha_inicio, fecha_fin, entidad_tipo, estado'
       )
       .eq('user_id', user.id);
+    if (startDate) programacionesQuery.gte('fecha_inicio', startDate);
+    if (endDate) programacionesQuery.lte('fecha_inicio', endDate);
+    const { data: programaciones, error: progError } = await programacionesQuery;
 
     if (progError) throw progError;
 


### PR DESCRIPTION
## Summary
- implement `EventFormModal` for friendly event creation
- fetch calendar data by date range and cache via `useUserEvents` and `useOperacionesEventos`
- support date range filtering in operations API
- lazy load OperationsCalendar in Calendario page
- integrate new modal and range logic in OperationsCalendar

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685c4429dc34832b8085ff77f975bbc1