### PR TITLE
Fix trip actions and restore detail modal

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,6 +28,7 @@ import Administracion from "./pages/Administracion"
 import Planes from "./pages/Planes"
 import ConfiguracionEmpresa from "./pages/ConfiguracionEmpresa"
 import Calendario from "./pages/Calendario"
+import ViajeEditar from "./pages/ViajeEditar"
 
 // Nuevos componentes
 import { ViajeWizard } from "./components/viajes/ViajeWizard"
@@ -121,6 +122,14 @@ const App = () => (
                 <AuthGuard>
                   <BaseLayout>
                     <ViajeWizard />
+                  </BaseLayout>
+                </AuthGuard>
+              } />
+
+              <Route path="/viajes/editar/:id" element={
+                <AuthGuard>
+                  <BaseLayout>
+                    <ViajeEditar />
                   </BaseLayout>
                 </AuthGuard>
               } />

--- a/src/pages/ViajeEditar.tsx
+++ b/src/pages/ViajeEditar.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { useParams } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import { Viaje } from '@/types/viaje';
+import { ViajeEditor } from '@/components/viajes/editor/ViajeEditor';
+import { Card, CardContent } from '@/components/ui/card';
+
+export default function ViajeEditar() {
+  const { id } = useParams<{ id: string }>();
+
+  const { data, isLoading, error, refetch } = useQuery({
+    queryKey: ['viaje', id],
+    queryFn: async () => {
+      if (!id) return null;
+      const { data, error } = await supabase
+        .from('viajes')
+        .select('*')
+        .eq('id', id)
+        .single();
+      if (error) throw error;
+      return data as Viaje;
+    }
+  });
+
+  if (isLoading) {
+    return <div className="p-8">Cargando viaje...</div>;
+  }
+
+  if (!data || error) {
+    return (
+      <Card className="p-8">
+        <CardContent>Error cargando el viaje.</CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="container mx-auto py-6">
+      <ViajeEditor viaje={data} onViajeUpdate={refetch} onClose={() => {}} />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add trip editor page and routing
- wire up view/edit/delete buttons on trips listing
- show detailed tracking modal when clicking view

## Testing
- `npm ci`
- `npm run lint` *(fails: 894 problems)*

------
https://chatgpt.com/codex/tasks/task_e_685c484aa9cc832bb06d90360d73d3e7