### PR TITLE
Improve mobile UX/UI on /viajes

### DIFF
--- a/src/components/analytics/ViajesAnalytics.tsx
+++ b/src/components/analytics/ViajesAnalytics.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { useIsMobile } from '@/hooks/use-mobile';
 import { 
   BarChart, 
   Bar, 
@@ -69,6 +70,8 @@ export const ViajesAnalytics = () => {
   const [analyticsData, setAnalyticsData] = useState<AnalyticsData | null>(null);
   const [selectedPeriod, setSelectedPeriod] = useState('30days');
   const [loading, setLoading] = useState(true);
+  const isMobile = useIsMobile();
+  const [activeIndex, setActiveIndex] = useState<number | undefined>(undefined);
 
   useEffect(() => {
     loadAnalyticsData();
@@ -219,10 +222,10 @@ export const ViajesAnalytics = () => {
 
         <Card>
           <CardContent className="p-6">
-            <div className="flex items-center justify-between">
+            <div className="costo-total-card">
               <div>
                 <p className="text-sm text-muted-foreground">Costo Total</p>
-                <p className="text-2xl font-bold">{formatCurrency(analyticsData.costos.total)}</p>
+                <p className="costo-total-valor font-bold">{formatCurrency(analyticsData.costos.total)}</p>
                 <p className="text-xs text-red-600 flex items-center">
                   <TrendingUp className="h-3 w-3 mr-1" />
                   +5% vs mes anterior
@@ -256,7 +259,7 @@ export const ViajesAnalytics = () => {
 
       {/* Gráficos principales */}
       <Tabs defaultValue="tendencias" className="w-full">
-        <TabsList>
+        <TabsList className="tabs-container">
           <TabsTrigger value="tendencias">Tendencias</TabsTrigger>
           <TabsTrigger value="estados">Estados de Viajes</TabsTrigger>
           <TabsTrigger value="costos">Análisis de Costos</TabsTrigger>
@@ -314,10 +317,13 @@ export const ViajesAnalytics = () => {
                       cx="50%"
                       cy="50%"
                       labelLine={false}
-                      label={({ name, percent }) => `${name} ${(percent * 100).toFixed(0)}%`}
+                      label={isMobile ? undefined : ({ name, percent }) => `${name} ${(percent * 100).toFixed(0)}%`}
                       outerRadius={80}
                       fill="#8884d8"
                       dataKey="value"
+                      activeIndex={activeIndex}
+                      onClick={(_, index) => setActiveIndex(index)}
+                      activeShape={{ outerRadius: 90, stroke: '#000', strokeWidth: 2 }}
                     >
                       {pieData.map((entry, index) => (
                         <Cell key={`cell-${index}`} fill={entry.color} />
@@ -326,6 +332,18 @@ export const ViajesAnalytics = () => {
                     <Tooltip />
                   </PieChart>
                 </ResponsiveContainer>
+                <ul className="pie-legend mt-4 flex flex-wrap justify-center gap-2">
+                  {pieData.map((entry, index) => (
+                    <li
+                      key={entry.name}
+                      onClick={() => setActiveIndex(index)}
+                      className={`flex items-center gap-1 cursor-pointer ${activeIndex === index ? 'font-medium' : ''}`}
+                    >
+                      <span className="w-3 h-3 rounded-sm" style={{ backgroundColor: entry.color }}></span>
+                      {entry.name}
+                    </li>
+                  ))}
+                </ul>
               </CardContent>
             </Card>
 

--- a/src/components/ui/FloatingActionButton.tsx
+++ b/src/components/ui/FloatingActionButton.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Plus } from 'lucide-react';
+
+interface FloatingActionButtonProps {
+  onClick: () => void;
+}
+
+export const FloatingActionButton: React.FC<FloatingActionButtonProps> = ({ onClick }) => {
+  return (
+    <div className="fab-container">
+      <button className="fab-button" onClick={onClick} aria-label="Programar Viaje">
+        <Plus className="fab-icon" />
+      </button>
+    </div>
+  );
+};

--- a/src/components/viajes/editor/ViajeEditor.tsx
+++ b/src/components/viajes/editor/ViajeEditor.tsx
@@ -121,7 +121,7 @@ export const ViajeEditor: React.FC<ViajeEditorProps> = ({
   };
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-6 viaje-editor-form">
       {/* Header */}
       <Card>
         <CardHeader>
@@ -183,7 +183,7 @@ export const ViajeEditor: React.FC<ViajeEditorProps> = ({
           </CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 viaje-editor-grid">
             <div>
               <Label htmlFor="origen">Origen</Label>
               <Input
@@ -217,7 +217,7 @@ export const ViajeEditor: React.FC<ViajeEditorProps> = ({
           </CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 viaje-editor-grid">
             <div>
               <Label htmlFor="fecha-inicio">Fecha y Hora de Inicio</Label>
               <Input
@@ -246,7 +246,7 @@ export const ViajeEditor: React.FC<ViajeEditorProps> = ({
           {(viaje.fecha_inicio_real || viaje.fecha_fin_real) && (
             <>
               <Separator />
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4 viaje-editor-grid">
                 {viaje.fecha_inicio_real && (
                   <div>
                     <Label>Fecha Real de Inicio</Label>
@@ -282,7 +282,7 @@ export const ViajeEditor: React.FC<ViajeEditorProps> = ({
           </CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 viaje-editor-grid">
             <div>
               <Label htmlFor="vehiculo">Vehículo</Label>
               <Input

--- a/src/index.css
+++ b/src/index.css
@@ -476,5 +476,57 @@
       overflow-x: auto;
       padding-bottom: 10px;
     }
+    .tabs-container {
+      display: flex;
+      overflow-x: auto;
+      -webkit-overflow-scrolling: touch;
+      scrollbar-width: none;
+    }
+    .tabs-container::-webkit-scrollbar {
+      display: none;
+    }
+    .tabs-container > * {
+      white-space: nowrap;
+    }
+    .costo-total-card {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+    .costo-total-valor {
+      font-size: clamp(1.5rem, 5vw, 2rem);
+    }
+    .desktop-programar-button {
+      display: none;
+    }
+    .fab-container {
+      position: fixed;
+      bottom: 2rem;
+      right: 2rem;
+      z-index: 1050;
+    }
+    .fab-button {
+      width: 56px;
+      height: 56px;
+      background-color: #4A69FF;
+      color: white;
+      border-radius: 50%;
+      border: none;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      box-shadow: 0 6px 10px rgba(0, 0, 0, 0.15);
+      cursor: pointer;
+      transition: transform 0.2s ease;
+    }
+    .fab-button:hover {
+      transform: scale(1.05);
+    }
+    .fab-icon {
+      font-size: 24px;
+    }
+    .viaje-editor-grid {
+      grid-template-columns: 1fr !important;
+    }
   }
 }

--- a/src/pages/ViajesOptimized.tsx
+++ b/src/pages/ViajesOptimized.tsx
@@ -12,6 +12,8 @@ import { toast } from 'sonner';
 import { Viaje } from '@/types/viaje';
 import { ViajeTrackingModal } from '@/components/modals/ViajeTrackingModal';
 import { useNavigate } from 'react-router-dom';
+import { useIsMobile } from '@/hooks/use-mobile';
+import { FloatingActionButton } from '@/components/ui/FloatingActionButton';
 
 // Lazy load components - fix for named export
 const ViajesAnalytics = lazy(() => 
@@ -42,6 +44,7 @@ function ViajesContent() {
   const navigate = useNavigate();
   const { viajes, isLoading, eliminarViaje } = useViajes();
   const { openViajeWizard } = useViajeWizardModal();
+  const isMobile = useIsMobile();
   const [selectedViaje, setSelectedViaje] = useState<Viaje | null>(null);
   const [showTrackingModal, setShowTrackingModal] = useState(false);
 
@@ -110,7 +113,7 @@ function ViajesContent() {
             Administra y da seguimiento a todos tus viajes de transporte
           </p>
         </div>
-        <Button onClick={openViajeWizard} className="flex items-center gap-2">
+        <Button onClick={openViajeWizard} className="flex items-center gap-2 desktop-programar-button">
           <Plus className="h-4 w-4" />
           Programar Viaje
         </Button>
@@ -245,6 +248,9 @@ function ViajesContent() {
         open={showTrackingModal}
         onOpenChange={setShowTrackingModal}
       />
+      {isMobile && (
+        <FloatingActionButton onClick={openViajeWizard} />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- create `FloatingActionButton` component
- tune Viajes analytics tabs and pie chart for mobile
- resize `Costo Total` card text on small screens
- hide desktop-only schedule button and show FAB
- ensure Viaje editor fields stack on mobile
- add responsive styles in `index.css`

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js' before install; installed and ran but linter reports many unrelated errors)*


------
https://chatgpt.com/codex/tasks/task_e_685c7f35f074832b978dcb8f2126625a