### PR TITLE
Fix trip finalization flow

### DIFF
--- a/src/components/viajes/ViajeWizard.tsx
+++ b/src/components/viajes/ViajeWizard.tsx
@@ -338,15 +338,15 @@ export const ViajeWizard = forwardRef<ViajeWizardHandle, ViajeWizardProps>(funct
       // Marcar como confirmado para prevenir duplicados
       setViajeConfirmado(true);
 
-      // 2. Generar Carta Porte desde el viaje
-      console.log('📄 Generando Carta Porte...');
-      const resultado = await ViajeCartaPorteService.crearCartaPorteDesdeViaje(
+      // 2. Generar borrador de Carta Porte desde el viaje
+      console.log('📄 Generando borrador de Carta Porte...');
+      const resultado = await ViajeCartaPorteService.crearBorradorDesdeViaje(
         nuevoViaje.id,
         data
       );
 
-      console.log('✅ Documentos generados exitosamente');
-      toast.success('Viaje programado y documentos generados exitosamente');
+      console.log('✅ Borrador creado exitosamente');
+      toast.success('Viaje programado correctamente');
       setInitialSnapshot(JSON.stringify(data));
       setHasUnsavedChanges(false);
 
@@ -355,13 +355,7 @@ export const ViajeWizard = forwardRef<ViajeWizardHandle, ViajeWizardProps>(funct
         if (onComplete) {
           onComplete();
         } else {
-          navigate('/viajes', {
-            state: {
-              message: 'Viaje programado y documentos generados exitosamente',
-              viajeId: nuevoViaje.id,
-              cartaPorteId: resultado.carta_porte.id
-            }
-          });
+          navigate(`/carta-porte/editor/${resultado.borrador_id}`);
         }
       }, 2000);
 

--- a/src/services/viajes/ViajeCartaPorteService.ts
+++ b/src/services/viajes/ViajeCartaPorteService.ts
@@ -6,7 +6,7 @@ import { supabase } from '@/integrations/supabase/client';
 
 export class ViajeCartaPorteService {
   static async crearCartaPorteDesdeViaje(
-    viajeId: string, 
+    viajeId: string,
     wizardData: ViajeWizardData
   ) {
     try {
@@ -57,6 +57,44 @@ export class ViajeCartaPorteService {
 
     } catch (error) {
       console.error('❌ Error creando Carta Porte desde viaje:', error);
+      throw error;
+    }
+  }
+
+  static async crearBorradorDesdeViaje(
+    viajeId: string,
+    wizardData: ViajeWizardData
+  ) {
+    try {
+      console.log('🚛 Iniciando creación de borrador de Carta Porte:', viajeId);
+
+      const cartaPorteData = ViajeToCartaPorteMapper.mapToValidCartaPorteFormat(
+        wizardData
+      );
+
+      const borrador = await CartaPorteLifecycleManager.crearBorrador({
+        nombre_borrador: `Viaje - ${
+          wizardData.cliente?.nombre_razon_social || 'Sin cliente'
+        }`,
+        datos_formulario: cartaPorteData,
+        version_formulario: '3.1'
+      });
+
+      console.log('📄 Borrador creado:', borrador.id);
+
+      const { error } = await supabase
+        .from('viajes')
+        .update({ carta_porte_id: borrador.id })
+        .eq('id', viajeId);
+
+      if (error) {
+        console.error('Error actualizando viaje con borrador:', error);
+        throw error;
+      }
+
+      return { viaje_id: viajeId, borrador_id: borrador.id };
+    } catch (error) {
+      console.error('❌ Error creando borrador desde viaje:', error);
       throw error;
     }
   }


### PR DESCRIPTION
## Summary
- create `ViajeCartaPorteService.crearBorradorDesdeViaje` to only generate a Carta Porte draft
- adjust `ViajeWizard` to use the new function and redirect to the Carta Porte editor

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js' before install; after installing, lint reports 828 errors)*

------
https://chatgpt.com/codex/tasks/task_e_685c834311dc832b98d9e51e862de285