### PR TITLE
Improve mobile dashboard layout

### DIFF
--- a/src/components/analytics/ViajesAnalytics.tsx
+++ b/src/components/analytics/ViajesAnalytics.tsx
@@ -184,7 +184,7 @@ export const ViajesAnalytics = () => {
             Análisis detallado del desempeño de su flota
           </p>
         </div>
-        <div className="flex gap-2">
+        <div className="flex gap-2 analytics-controls-container">
           <Select value={selectedPeriod} onValueChange={setSelectedPeriod}>
             <SelectTrigger className="w-40">
               <SelectValue />
@@ -206,7 +206,7 @@ export const ViajesAnalytics = () => {
       <div className="summary-cards-container grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
         <Card>
           <CardContent className="p-6">
-            <div className="flex items-center justify-between">
+            <div className="stat-card">
               <div>
                 <p className="text-sm text-muted-foreground">Total Viajes</p>
                 <p className="text-2xl font-bold">{analyticsData.viajes.total}</p>
@@ -215,7 +215,7 @@ export const ViajesAnalytics = () => {
                   +12% vs mes anterior
                 </p>
               </div>
-              <div className="p-3 bg-blue-100 rounded-full">
+              <div className="icon-container p-3 bg-blue-100 rounded-full">
                 <Truck className="h-6 w-6 text-blue-600" />
               </div>
             </div>
@@ -224,7 +224,7 @@ export const ViajesAnalytics = () => {
 
         <Card>
           <CardContent className="p-6">
-            <div className="flex items-center justify-between">
+            <div className="stat-card">
               <div>
                 <p className="text-sm text-muted-foreground">Puntualidad</p>
                 <p className="text-2xl font-bold">{analyticsData.eficiencia.puntualidad}%</p>
@@ -233,7 +233,7 @@ export const ViajesAnalytics = () => {
                   +2.1% vs mes anterior
                 </p>
               </div>
-              <div className="p-3 bg-green-100 rounded-full">
+              <div className="icon-container p-3 bg-green-100 rounded-full">
                 <Clock className="h-6 w-6 text-green-600" />
               </div>
             </div>
@@ -242,7 +242,7 @@ export const ViajesAnalytics = () => {
 
         <Card>
           <CardContent className="p-6">
-            <div className="costo-total-card">
+            <div className="costo-total-card stat-card">
               <div>
                 <p className="text-sm text-muted-foreground">Costo Total</p>
                 <p className="costo-total-valor font-bold">{formatCurrency(analyticsData.costos.total)}</p>
@@ -251,7 +251,7 @@ export const ViajesAnalytics = () => {
                   +5% vs mes anterior
                 </p>
               </div>
-              <div className="costo-total-icon">
+              <div className="costo-total-icon icon-container">
                 <DollarSign className="h-6 w-6 text-red-600" />
               </div>
             </div>
@@ -260,7 +260,7 @@ export const ViajesAnalytics = () => {
 
         <Card>
           <CardContent className="p-6">
-            <div className="flex items-center justify-between">
+            <div className="stat-card">
               <div>
                 <p className="text-sm text-muted-foreground">Km/Litro</p>
                 <p className="text-2xl font-bold">{analyticsData.eficiencia.kmPorLitro}</p>
@@ -269,7 +269,7 @@ export const ViajesAnalytics = () => {
                   +0.3 vs mes anterior
                 </p>
               </div>
-              <div className="p-3 bg-yellow-100 rounded-full">
+              <div className="icon-container p-3 bg-yellow-100 rounded-full">
                 <Fuel className="h-6 w-6 text-yellow-600" />
               </div>
             </div>

--- a/src/index.css
+++ b/src/index.css
@@ -476,28 +476,17 @@
       overflow-x: auto;
       padding-bottom: 10px;
     }
+    .analytics-controls-container {
+      flex-direction: column;
+      align-items: stretch;
+      gap: 0.5rem;
+    }
     .tabs-container {
       position: relative;
       display: flex;
-      overflow-x: auto;
-      -webkit-overflow-scrolling: touch;
-      scrollbar-width: none;
-    }
-    .tabs-container::-webkit-scrollbar {
-      display: none;
-    }
-    .tabs-container > * {
-      white-space: nowrap;
-    }
-    .scroll-gradient::after {
-      content: '';
-      position: absolute;
-      right: 0;
-      top: 0;
-      bottom: 0;
-      width: 30px;
-      pointer-events: none;
-      background: linear-gradient(to left, #ffffff, rgba(255, 255, 255, 0));
+      flex-wrap: wrap;
+      justify-content: flex-start;
+      gap: 0.5rem;
     }
     .costo-total-card {
       display: flex;
@@ -526,6 +515,20 @@
     .costo-total-icon svg {
       position: relative;
       z-index: 1;
+    }
+    .stat-card {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+    .stat-card .icon-container {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 48px;
+      height: 48px;
+      border-radius: 50%;
+      flex-shrink: 0;
     }
     .desktop-programar-button {
       display: none;
@@ -584,6 +587,12 @@
       width: 100%;
       justify-content: space-around;
       margin-top: 0.75rem;
+    }
+    .viaje-card .address-text {
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      max-width: 250px;
     }
     .viaje-card-status {
       position: absolute;

--- a/src/pages/ViajesOptimized.tsx
+++ b/src/pages/ViajesOptimized.tsx
@@ -179,7 +179,7 @@ function ViajesContent() {
                       <div className="flex-1 min-w-0">
                         <div className="flex items-center gap-3 mb-2">
                           <MapPin className="h-4 w-4 text-gray-500 flex-shrink-0" />
-                          <span className="font-medium text-lg truncate">
+                          <span className="font-medium text-lg address-text">
                             {viaje.origen} → {viaje.destino}
                           </span>
                           <Badge className={`viaje-card-status ${estadoColors[viaje.estado]}`}>


### PR DESCRIPTION
## Summary
- adjust analytic controls layout on mobile
- tweak tabs to wrap on small screens
- add common styles for stat cards
- clamp trip address text

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685d63864234832b9539c6bbcc291424