### PR TITLE
Improve mobile tabs UX

### DIFF
--- a/src/components/analytics/ViajesAnalytics.tsx
+++ b/src/components/analytics/ViajesAnalytics.tsx
@@ -279,15 +279,14 @@ export const ViajesAnalytics = () => {
 
       {/* Gráficos principales */}
       <Tabs defaultValue="tendencias" className="w-full">
-        <TabsList
-          ref={tabsRef}
-          className={`tabs-container ${showTabsShadow ? 'scroll-gradient' : ''}`}
-        >
-          <TabsTrigger value="tendencias">Tendencias</TabsTrigger>
-          <TabsTrigger value="estados">Estados de Viajes</TabsTrigger>
-          <TabsTrigger value="costos">Análisis de Costos</TabsTrigger>
-          <TabsTrigger value="eficiencia">Eficiencia</TabsTrigger>
-        </TabsList>
+        <div className={`tabs-wrapper ${showTabsShadow ? 'scroll-gradient' : ''}`}>
+          <TabsList ref={tabsRef} className="tabs-container">
+            <TabsTrigger value="tendencias">Tendencias</TabsTrigger>
+            <TabsTrigger value="estados">Estados de Viajes</TabsTrigger>
+            <TabsTrigger value="costos">Análisis de Costos</TabsTrigger>
+            <TabsTrigger value="eficiencia">Eficiencia</TabsTrigger>
+          </TabsList>
+        </div>
 
         <TabsContent value="tendencias" className="space-y-6">
           <Card>

--- a/src/index.css
+++ b/src/index.css
@@ -530,12 +530,33 @@
       align-items: stretch;
       gap: 0.5rem;
     }
-    .tabs-container {
+    .tabs-wrapper {
       position: relative;
+    }
+
+    .tabs-wrapper.scroll-gradient::after {
+      content: '';
+      position: absolute;
+      right: 0;
+      top: 0;
+      bottom: 0;
+      width: 40px;
+      background: linear-gradient(to left, var(--pure-white), rgba(255, 255, 255, 0));
+      pointer-events: none;
+    }
+
+    .tabs-container {
       display: flex;
-      flex-wrap: wrap;
-      justify-content: flex-start;
+      overflow-x: auto;
+      white-space: nowrap;
+      -webkit-overflow-scrolling: touch;
+      scrollbar-width: none;
       gap: 0.5rem;
+      padding-right: 40px;
+    }
+
+    .tabs-container::-webkit-scrollbar {
+      display: none;
     }
     .costo-total-card {
       display: flex;


### PR DESCRIPTION
## Summary
- implement mobile only scrollable tabs with gradient indicator
- wrap analytics tabs in `tabs-wrapper` div

## Testing
- `npm run lint` *(fails: Unexpected any, prefer-const, and no require imports)*

------
https://chatgpt.com/codex/tasks/task_e_685dbe6ff5f4832bae93668794a8d0cc