### PR TITLE
Fix mobile widget text and spacing

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -650,7 +650,7 @@
     flex-direction: column;
     justify-content: space-between;
     align-items: flex-start;
-    padding: 12px !important;
+    padding: 10px !important;
     box-sizing: border-box;
   }
 
@@ -659,9 +659,10 @@
   .metric-card > div:first-child {
     display: flex;
     justify-content: space-between;
-    align-items: center;
+    align-items: flex-start;
     width: 100%;
-    margin-bottom: 8px;
+    height: 18px !important;
+    margin-bottom: 4px;
   }
 
   /* Títulos de widgets */
@@ -669,20 +670,32 @@
   .widget-card .title,
   .metric-card .title,
   [class*="title"] {
-    font-size: 11px !important;
-    font-weight: 500 !important;
+    font-size: 10px !important;
+    font-weight: 600 !important;
     color: #6B7280 !important;
-    margin: 0 !important;
-    line-height: 1.2;
-    flex-grow: 1;
+    line-height: 1.1 !important;
+    margin: 0 0 4px 0 !important;
+    white-space: nowrap !important;
+    overflow: hidden !important;
+    text-overflow: ellipsis !important;
+    max-width: calc(100% - 30px) !important;
+  }
+  .summary-cards-container > *:nth-child(2) .text-content p:first-child {
+    white-space: normal !important;
+    line-height: 1.0 !important;
+    height: 16px !important;
+    overflow: hidden !important;
+    display: -webkit-box !important;
+    -webkit-line-clamp: 2 !important;
+    -webkit-box-orient: vertical !important;
   }
 
   /* Íconos de widget */
   .widget-card .icon,
   .metric-card .icon,
   [class*="icon"] {
-    width: 24px !important;
-    height: 24px !important;
+    width: 20px !important;
+    height: 20px !important;
     flex-shrink: 0;
   }
 
@@ -691,11 +704,11 @@
   .widget-card .number,
   .metric-card .value,
   [class*="value"] {
-    font-size: 24px !important;
+    font-size: 22px !important;
     font-weight: 700 !important;
     color: #111827 !important;
     line-height: 1.1 !important;
-    margin: 8px 0 4px 0 !important;
+    margin: 6px 0 4px 0 !important;
   }
 
   /* Indicadores de cambio */
@@ -703,8 +716,11 @@
   .widget-card .percentage,
   .metric-card .change,
   [class*="change"] {
-    font-size: 10px !important;
+    font-size: 9px !important;
     font-weight: 500 !important;
+    white-space: nowrap !important;
+    overflow: hidden !important;
+    text-overflow: ellipsis !important;
     line-height: 1.2 !important;
     margin: 0 !important;
   }
@@ -714,7 +730,7 @@
   .metric-card:has([text*="Costo"]),
   [class*="cost"] .value,
   [class*="costo"] .value {
-    font-size: 20px !important;
+    font-size: 18px !important;
     letter-spacing: -0.5px !important;
   }
 
@@ -733,8 +749,8 @@
   .metrics-section {
     display: grid !important;
     grid-template-columns: 1fr 1fr !important;
-    gap: 8px !important;
-    padding: 12px !important;
+    gap: 6px !important;
+    padding: 8px !important;
     width: 100% !important;
     box-sizing: border-box !important;
   }
@@ -743,9 +759,19 @@
   .dashboard-content > *,
   .widgets-container > *,
   .metrics-section > * {
-    min-height: 110px !important;
-    max-height: 130px !important;
+    min-height: 100px !important;
+    max-height: 115px !important;
     width: 100% !important;
+    box-sizing: border-box !important;
+  }
+  .widget-card *,
+  .metric-card * {
+    word-wrap: break-word !important;
+    overflow-wrap: break-word !important;
+  }
+  .widget-card,
+  .metric-card {
+    max-width: calc(50vw - 10px) !important;
     box-sizing: border-box !important;
   }
 


### PR DESCRIPTION
## Summary
- tweak mobile widget styles so titles fit
- reduce widget spacing on analytics/viajes
- keep numbers legible on small screens

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685dd227c25c832bbb026c00af276a61