### PR TITLE
Fix mobile analytics selectors

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -641,164 +641,103 @@
 
 /* SOLO para vista móvil en /viajes */
 @media (max-width: 768px) {
-  /* Reorganizar contenido DENTRO del widget existente */
-  .widget-card,
-  .metric-card,
-  [class*="widget"],
-  [class*="metric"] {
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
-    align-items: flex-start;
-    padding: 10px !important;
-    box-sizing: border-box;
+  /* Contenedor de tarjetas de resumen */
+  .summary-cards-container,
+  .analytics-summary,
+  .dashboard-summary,
+  [class*="summary"],
+  [class*="cards"] {
+    display: grid !important;
+    grid-template-columns: 1fr 1fr !important;
+    gap: 4px !important;
+    padding: 6px !important;
+    width: 100% !important;
+    box-sizing: border-box !important;
   }
 
-  /* Área del título e ícono */
-  .widget-card > div:first-child,
-  .metric-card > div:first-child {
-    display: flex;
-    justify-content: space-between;
-    align-items: flex-start;
-    width: 100%;
-    height: 18px !important;
-    margin-bottom: 4px;
+  /* Tarjeta individual dentro del contenedor */
+  .summary-cards-container > *,
+  .analytics-summary > *,
+  .dashboard-summary > *,
+  [class*="summary"] > *,
+  [class*="cards"] > * {
+    padding: 8px !important;
+    min-height: 95px !important;
+    max-height: 110px !important;
+    border-radius: 12px !important;
+    background: white !important;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1) !important;
+    display: flex !important;
+    flex-direction: column !important;
+    justify-content: space-between !important;
+    box-sizing: border-box !important;
   }
 
-  /* Títulos de widgets */
-  .widget-card h3,
-  .widget-card .title,
-  .metric-card .title,
-  [class*="title"] {
-    font-size: 10px !important;
+  /* Títulos */
+  [class*="text"] p:first-child,
+  .text-content p:first-child,
+  h3:first-child,
+  p:first-child {
+    font-size: 9px !important;
     font-weight: 600 !important;
     color: #6B7280 !important;
-    line-height: 1.1 !important;
     margin: 0 0 4px 0 !important;
-    white-space: nowrap !important;
-    overflow: hidden !important;
-    text-overflow: ellipsis !important;
-    max-width: calc(100% - 30px) !important;
+    line-height: 1.1 !important;
   }
-  .summary-cards-container > *:nth-child(2) .text-content p:first-child {
+
+  /* Segundo widget: Puntualidad */
+  .summary-cards-container > *:nth-child(2) p:first-child,
+  [class*="summary"] > *:nth-child(2) p:first-child,
+  [class*="cards"] > *:nth-child(2) p:first-child {
+    font-size: 8px !important;
     white-space: normal !important;
-    line-height: 1.0 !important;
-    height: 16px !important;
+    line-height: 0.9 !important;
+    height: 14px !important;
     overflow: hidden !important;
     display: -webkit-box !important;
     -webkit-line-clamp: 2 !important;
     -webkit-box-orient: vertical !important;
+    word-spacing: -1px !important;
   }
 
-  /* Íconos de widget */
-  .widget-card .icon,
-  .metric-card .icon,
-  [class*="icon"] {
-    width: 20px !important;
-    height: 20px !important;
-    flex-shrink: 0;
+  /* Tercer widget: Costo Total */
+  .summary-cards-container > *:nth-child(3) p:first-child,
+  [class*="summary"] > *:nth-child(3) p:first-child,
+  [class*="cards"] > *:nth-child(3) p:first-child {
+    font-size: 8px !important;
+    letter-spacing: -0.3px !important;
   }
 
   /* Valores principales */
-  .widget-card .value,
-  .widget-card .number,
-  .metric-card .value,
-  [class*="value"] {
-    font-size: 22px !important;
+  [class*="text"] p:nth-child(2),
+  .text-content p:nth-child(2),
+  h2,
+  h1,
+  .value,
+  .number {
+    font-size: 20px !important;
     font-weight: 700 !important;
     color: #111827 !important;
-    line-height: 1.1 !important;
-    margin: 6px 0 4px 0 !important;
+    line-height: 1 !important;
+    margin: 4px 0 !important;
   }
 
-  /* Indicadores de cambio */
-  .widget-card .change,
-  .widget-card .percentage,
-  .metric-card .change,
-  [class*="change"] {
-    font-size: 9px !important;
-    font-weight: 500 !important;
-    white-space: nowrap !important;
-    overflow: hidden !important;
-    text-overflow: ellipsis !important;
-    line-height: 1.2 !important;
-    margin: 0 !important;
-  }
-
-  /* Widget de costo que se desborda */
-  .widget-card:has([text*="Costo"]),
-  .metric-card:has([text*="Costo"]),
-  [class*="cost"] .value,
-  [class*="costo"] .value {
-    font-size: 18px !important;
+  /* Valor de costo total (más largo) */
+  .summary-cards-container > *:nth-child(3) [class*="text"] p:nth-child(2),
+  .summary-cards-container > *:nth-child(3) .text-content p:nth-child(2) {
+    font-size: 16px !important;
     letter-spacing: -0.5px !important;
   }
 
-  /* Asegurar que números largos no se desborden */
-  .currency,
-  [class*="currency"] {
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    max-width: 100%;
-  }
-
-  /* Contenedor existente de widgets */
-  .dashboard-content,
-  .widgets-container,
-  .metrics-section {
-    display: grid !important;
-    grid-template-columns: 1fr 1fr !important;
-    gap: 6px !important;
-    padding: 8px !important;
-    width: 100% !important;
-    box-sizing: border-box !important;
-  }
-
-  /* Cada widget individual */
-  .dashboard-content > *,
-  .widgets-container > *,
-  .metrics-section > * {
-    min-height: 100px !important;
-    max-height: 115px !important;
-    width: 100% !important;
-    box-sizing: border-box !important;
-  }
-  .widget-card *,
-  .metric-card * {
-    word-wrap: break-word !important;
-    overflow-wrap: break-word !important;
-  }
-  .widget-card,
-  .metric-card {
-    max-width: calc(50vw - 10px) !important;
-    box-sizing: border-box !important;
-  }
-
-  /* Menú de Pestañas */
-  .tabs-container,
-  .navigation-tabs {
-    display: flex !important;
-    overflow-x: auto !important;
-    scrollbar-width: none !important;
-    -webkit-overflow-scrolling: touch !important;
-    padding: 0 12px !important;
-  }
-
-  .tabs-container::-webkit-scrollbar {
-    display: none !important;
-  }
-
-  /* Pestañas individuales existentes */
-  .tab,
-  .tab-item,
-  .navigation-tabs > * {
-    flex: 0 0 auto !important;
-    padding: 8px 12px !important;
-    margin-right: 6px !important;
-    font-size: 12px !important;
-    white-space: nowrap !important;
-    border-radius: 16px !important;
+  /* Indicadores de cambio */
+  [class*="text"] p:last-child,
+  .text-content p:last-child,
+  .change,
+  .percentage {
+    font-size: 8px !important;
+    font-weight: 500 !important;
+    line-height: 1.1 !important;
+    margin: 0 !important;
   }
 }
 }


### PR DESCRIPTION
## Summary
- update mobile layout rules for Viajes analytics with correct selectors

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685ddfd3b978832b923e812318c90469