### PR TITLE
Fix resource indicator layout

### DIFF
--- a/src/pages/Planes.tsx
+++ b/src/pages/Planes.tsx
@@ -99,7 +99,7 @@ export default function Planes() {
             </div>
           </CardHeader>
           <CardContent>
-            <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4">
+            <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
               {/* Conductores */}
               <div className="space-y-2">
                 <LimitUsageIndicator


### PR DESCRIPTION
## Summary
- simplify columns in the plan overview grid so items show in a 2x3 layout

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: needs vitest package install)*

------
https://chatgpt.com/codex/tasks/task_e_685eadbb464c832b92cb191d2aec39b9