### PR TITLE
Improve mobile view for plans and trips

### DIFF
--- a/src/components/common/LimitUsageIndicator.tsx
+++ b/src/components/common/LimitUsageIndicator.tsx
@@ -71,7 +71,7 @@ export const LimitUsageIndicator = ({
           {isUnlimited && <span className="text-xs">ilimitado</span>}
         </Badge>
         {!isUnlimited && (
-          <span className="text-xs text-muted-foreground">
+          <span className="text-xs text-muted-foreground usage-percentage">
             {percentage.toFixed(0)}%
           </span>
         )}

--- a/src/index.css
+++ b/src/index.css
@@ -675,6 +675,37 @@
   .summary-cards-container > *:nth-child(3) h2 {
     font-size: 20px !important;
   }
+
+  /* Mobile styles for plan usage card */
+  .plan-usage-card .usage-percentage {
+    display: none;
+  }
+
+  /* Scrollable tabs for mobile menus */
+  .scrollable-tabs-container {
+    display: flex;
+    overflow-x: auto;
+    white-space: nowrap;
+    -webkit-overflow-scrolling: touch;
+    position: relative;
+    scrollbar-width: none;
+  }
+  .scrollable-tabs-container::-webkit-scrollbar {
+    display: none;
+  }
+  .scrollable-tabs-container-wrapper {
+    position: relative;
+  }
+  .scrollable-tabs-container-wrapper::after {
+    content: '';
+    position: absolute;
+    right: 0;
+    top: 0;
+    bottom: 0;
+    width: 40px;
+    background: linear-gradient(to left, var(--pure-white), rgba(255, 255, 255, 0));
+    pointer-events: none;
+  }
 }
   }
 }

--- a/src/pages/Planes.tsx
+++ b/src/pages/Planes.tsx
@@ -74,7 +74,7 @@ export default function Planes() {
         </div>
 
         {/* Tarjeta principal del plan con conteos reales */}
-        <Card>
+        <Card className="plan-usage-card">
           <CardHeader>
             <div className="flex items-center justify-between">
               <div>
@@ -155,12 +155,14 @@ export default function Planes() {
 
         {/* Detalles y gestión */}
         <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
-          <TabsList className="grid w-full grid-cols-4">
-            <TabsTrigger value="plan">Plan Actual</TabsTrigger>
-            <TabsTrigger value="uso">Uso de Recursos</TabsTrigger>
-            <TabsTrigger value="cambiar">Cambiar Plan</TabsTrigger>
-            <TabsTrigger value="facturacion">Facturación</TabsTrigger>
-          </TabsList>
+          <div className="scrollable-tabs-container-wrapper">
+            <TabsList className="grid w-full grid-cols-4 scrollable-tabs-container">
+              <TabsTrigger value="plan">Plan Actual</TabsTrigger>
+              <TabsTrigger value="uso">Uso de Recursos</TabsTrigger>
+              <TabsTrigger value="cambiar">Cambiar Plan</TabsTrigger>
+              <TabsTrigger value="facturacion">Facturación</TabsTrigger>
+            </TabsList>
+          </div>
 
           <TabsContent value="plan" className="space-y-6">
             <Card>

--- a/src/pages/ViajesOptimized.tsx
+++ b/src/pages/ViajesOptimized.tsx
@@ -260,13 +260,14 @@ function ViajesContent() {
           </div>
 
           <Tabs defaultValue="activos" className="w-full">
-            <TabsList className="grid w-full grid-cols-4">
-              <TabsTrigger value="activos">
-                Activos
-                <Badge variant="secondary" className="ml-2">
-                  {viajesActivos.length}
-                </Badge>
-              </TabsTrigger>
+            <div className="scrollable-tabs-container-wrapper">
+              <TabsList className="grid w-full grid-cols-4 scrollable-tabs-container">
+                <TabsTrigger value="activos">
+                  Activos
+                  <Badge variant="secondary" className="ml-2">
+                    {viajesActivos.length}
+                  </Badge>
+                </TabsTrigger>
               <TabsTrigger value="programados">
                 Programados
                 <Badge variant="secondary" className="ml-2">
@@ -286,6 +287,7 @@ function ViajesContent() {
                 </Badge>
               </TabsTrigger>
             </TabsList>
+            </div>
 
             <TabsContent value="activos" className="mt-6">
               {renderViajesList(viajesActivos, "No hay viajes activos")}


### PR DESCRIPTION
## Summary
- tweak plan usage card to mark mobile tweaks
- hide usage percentage on small screens
- make tabs menus scrollable on mobile

## Testing
- `npm run lint` *(fails: cannot fix massive lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_685eb97bf444832b8538ca9bac9388be