### PR TITLE
Improve mobile layout on plan usage

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -677,7 +677,19 @@
   }
 
   /* Mobile styles for plan usage card */
-  .plan-usage-card .usage-percentage {
+  .plan-usage-grid {
+    grid-template-columns: 1fr;
+    gap: 1.5rem;
+  }
+
+  .usage-item-container {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
+  }
+
+  .usage-item-container .usage-percentage {
     display: none;
   }
 

--- a/src/pages/Planes.tsx
+++ b/src/pages/Planes.tsx
@@ -99,30 +99,30 @@ export default function Planes() {
             </div>
           </CardHeader>
           <CardContent>
-            <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+            <div className="grid grid-cols-2 md:grid-cols-3 gap-4 plan-usage-grid">
               {/* Conductores */}
-              <div className="space-y-2">
+              <div className="space-y-2 usage-item-container">
                 <LimitUsageIndicator
                   resourceType="conductores"
                 />
               </div>
 
               {/* Vehículos */}
-              <div className="space-y-2">
+              <div className="space-y-2 usage-item-container">
                 <LimitUsageIndicator
                   resourceType="vehiculos"
                 />
               </div>
 
               {/* Socios */}
-              <div className="space-y-2">
+              <div className="space-y-2 usage-item-container">
                 <LimitUsageIndicator
                   resourceType="socios"
                 />
               </div>
 
               {/* Remolques */}
-              <div className="space-y-2">
+              <div className="space-y-2 usage-item-container">
                 {permissions.usage.remolques?.limit ? (
                   <LimitUsageIndicator
                     resourceType="remolques"
@@ -133,14 +133,14 @@ export default function Planes() {
               </div>
 
               {/* Cartas Porte */}
-              <div className="space-y-2">
+              <div className="space-y-2 usage-item-container">
                 <LimitUsageIndicator
                   resourceType="cartas_porte"
                 />
               </div>
 
               {/* Viajes */}
-              <div className="space-y-2">
+              <div className="space-y-2 usage-item-container">
                 {permissions.usage.viajes?.limit ? (
                   <LimitUsageIndicator
                     resourceType="viajes"


### PR DESCRIPTION
## Summary
- reflow plan usage grid for mobile
- style usage items vertically for mobile
- hide usage percentage on mobile
- keep last item consistent

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npx vitest run` *(fails: missing dependency 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_685ebe066a9c832b89d825252fcc4155