### PR TITLE
Fix empty viajes list layout

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -400,6 +400,11 @@
     background: rgba(255, 255, 255, 0.8);
     border: 1px solid rgba(255, 255, 255, 0.2);
   }
+
+  /* Empty state container for viajes list */
+  .empty-state-container {
+    @apply flex flex-col justify-center items-center gap-6 p-8 min-h-[300px];
+  }
 }
 
 @layer utilities {

--- a/src/pages/ViajesOptimized.tsx
+++ b/src/pages/ViajesOptimized.tsx
@@ -91,7 +91,7 @@ function ViajesContent() {
   const renderViajesList = (viajesList: Viaje[], emptyMessage: string) => {
     if (viajesList.length === 0) {
       return (
-        <div className="text-center py-12">
+        <div className="empty-state-container text-center">
           <Route className="h-12 w-12 text-gray-400 mx-auto mb-4" />
           <p className="text-lg font-medium text-gray-900 mb-2">{emptyMessage}</p>
           <Button onClick={openViajeWizard} className="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- center empty state container with flexbox utility class
- apply the new class in the viajes list

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685f23121228832b849361943e796f8e