### PR TITLE
Improve dashboard responsive widgets

### DIFF
--- a/src/components/layout/BaseLayout.tsx
+++ b/src/components/layout/BaseLayout.tsx
@@ -25,7 +25,7 @@ export function BaseLayout({ children, showSidebar = true, className }: BaseLayo
         <GlobalHeader />
         <main
           className={cn(
-            "transition-all duration-200",
+            "transition-all duration-200 overflow-x-hidden",
             "p-3 sm:p-4 md:p-6 lg:p-8",
             "min-h-[calc(100vh-64px)] md:min-h-[calc(100vh-72px)]",
             className
@@ -52,8 +52,8 @@ export function BaseLayout({ children, showSidebar = true, className }: BaseLayo
         <div className="flex-1 flex flex-col w-full min-w-0">
           <GlobalHeader onOpenSidebar={() => setMobileOpen(true)} />
           <main
-            className={cn(
-              "flex-1 overflow-auto transition-all duration-200",
+          className={cn(
+              "flex-1 overflow-auto overflow-x-hidden transition-all duration-200",
               "p-3 sm:p-4 md:p-6 lg:p-8",
               "space-y-4 sm:space-y-6",
               className

--- a/src/components/ui/carousel.tsx
+++ b/src/components/ui/carousel.tsx
@@ -204,9 +204,9 @@ const CarouselPrevious = React.forwardRef<
       variant={variant}
       size={size}
       className={cn(
-        "absolute  h-8 w-8 rounded-full",
+        "absolute h-8 w-8 rounded-full",
         orientation === "horizontal"
-          ? "-left-12 top-1/2 -translate-y-1/2"
+          ? "left-2 top-1/2 -translate-y-1/2 sm:-left-12"
           : "-top-12 left-1/2 -translate-x-1/2 rotate-90",
         className
       )}
@@ -235,7 +235,7 @@ const CarouselNext = React.forwardRef<
       className={cn(
         "absolute h-8 w-8 rounded-full",
         orientation === "horizontal"
-          ? "-right-12 top-1/2 -translate-y-1/2"
+          ? "right-2 top-1/2 -translate-y-1/2 sm:-right-12"
           : "-bottom-12 left-1/2 -translate-x-1/2 rotate-90",
         className
       )}

--- a/src/index.css
+++ b/src/index.css
@@ -166,6 +166,7 @@
     -moz-osx-font-smoothing: grayscale;
     text-rendering: optimizeLegibility;
     font-feature-settings: 'kern' 1, 'liga' 1;
+    overflow-x: hidden;
   }
 
   /* Apple Typography System */


### PR DESCRIPTION
## Summary
- prevent horizontal overflow in BaseLayout
- contain carousel navigation buttons on mobile
- hide body overflow

## Testing
- `npm run lint` *(fails: cannot find package or lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_685f2662c708832baaca8f7ffe946d29