### PR TITLE
Fix type issues in vehicle form and dashboard counts

### DIFF
--- a/src/components/vehiculos/forms/VehiculoFormRefactored.tsx
+++ b/src/components/vehiculos/forms/VehiculoFormRefactored.tsx
@@ -17,7 +17,29 @@ interface VehiculoFormRefactoredProps {
 }
 
 export function VehiculoFormRefactored({ vehiculoId, onSuccess, onCancel }: VehiculoFormRefactoredProps) {
-  const [formData, setFormData] = useState({
+  const [formData, setFormData] = useState<{
+    placa: string;
+    marca: string;
+    modelo: string;
+    anio: string;
+    numero_serie_vin: string;
+    config_vehicular: string;
+    perm_sct: string;
+    num_permiso_sct: string;
+    vigencia_permiso: string;
+    asegura_resp_civil: string;
+    poliza_resp_civil: string;
+    asegura_med_ambiente: string;
+    poliza_med_ambiente: string;
+    vigencia_seguro: string;
+    capacidad_carga: string;
+    tipo_carroceria: string;
+    peso_bruto_vehicular: string;
+    verificacion_vigencia: string;
+    estado: string;
+    tipo_combustible: '' | 'diesel' | 'gasolina';
+    rendimiento: string;
+  }>({
     placa: '',
     marca: '',
     modelo: '',
@@ -68,7 +90,7 @@ export function VehiculoFormRefactored({ vehiculoId, onSuccess, onCancel }: Vehi
         peso_bruto_vehicular: vehiculoActual.peso_bruto_vehicular?.toString() || '',
         verificacion_vigencia: vehiculoActual.verificacion_vigencia || '',
         estado: vehiculoActual.estado || 'disponible',
-        tipo_combustible: vehiculoActual.tipo_combustible || '',
+        tipo_combustible: (vehiculoActual.tipo_combustible as 'diesel' | 'gasolina' | null) ?? '',
         rendimiento: vehiculoActual.rendimiento?.toString() || ''
       });
     }
@@ -107,6 +129,7 @@ export function VehiculoFormRefactored({ vehiculoId, onSuccess, onCancel }: Vehi
         capacidad_carga: formData.capacidad_carga ? parseFloat(formData.capacidad_carga) : undefined,
         peso_bruto_vehicular: formData.peso_bruto_vehicular ? parseFloat(formData.peso_bruto_vehicular) : undefined,
         rendimiento: formData.rendimiento ? parseFloat(formData.rendimiento) : undefined,
+        tipo_combustible: (formData.tipo_combustible || undefined) as 'diesel' | 'gasolina' | undefined,
         activo: true
       };
 

--- a/src/hooks/useDashboardCounts.ts
+++ b/src/hooks/useDashboardCounts.ts
@@ -24,32 +24,41 @@ export const useDashboardCounts = () => {
       const start = startOfMonth(now);
       const end = endOfMonth(now);
 
-      const [vehiculosRes, conductoresRes, sociosRes, remolquesRes, cartasRes, viajesRes] = await Promise.all([
-        supabase.from('vehiculos').select('id', { count: 'exact' }).eq('user_id', user.id),
-        supabase.from('conductores').select('id', { count: 'exact' }).eq('user_id', user.id),
-        supabase.from('socios').select('id', { count: 'exact' }).eq('user_id', user.id),
-        supabase.from('remolques_ccp').select('id', { count: 'exact' }).eq('user_id', user.id),
-        supabase
-          .from('cartas_porte')
-          .select('id', { count: 'exact' })
-          .eq('usuario_id', user.id)
-          .gte('created_at', start.toISOString())
-          .lte('created_at', end.toISOString()),
-        supabase
-          .from('viajes')
-          .select('id', { count: 'exact' })
-          .eq('user_id', user.id)
-          .gte('created_at', start.toISOString())
-          .lte('created_at', end.toISOString()),
-      ]);
+      const { count: vehiculosCount } = (await (supabase.from('vehiculos') as any)
+        .select('*', { count: 'exact', head: true })
+        .eq('user_id', user.id)) as { count: number | null };
+
+      const { count: conductoresCount } = (await (supabase.from('conductores') as any)
+        .select('*', { count: 'exact', head: true })
+        .eq('user_id', user.id)) as { count: number | null };
+
+      const { count: sociosCount } = (await (supabase.from('socios') as any)
+        .select('*', { count: 'exact', head: true })
+        .eq('user_id', user.id)) as { count: number | null };
+
+      const { count: remolquesCount } = (await (supabase.from('remolques_ccp') as any)
+        .select('*', { count: 'exact', head: true })
+        .eq('user_id', user.id)) as { count: number | null };
+
+      const { count: cartasCount } = (await (supabase.from('cartas_porte') as any)
+        .select('*', { count: 'exact', head: true })
+        .eq('usuario_id', user.id)
+        .gte('created_at', start.toISOString())
+        .lte('created_at', end.toISOString())) as { count: number | null };
+
+      const { count: viajesCount } = (await (supabase.from('viajes') as any)
+        .select('*', { count: 'exact', head: true })
+        .eq('user_id', user.id)
+        .gte('created_at', start.toISOString())
+        .lte('created_at', end.toISOString())) as { count: number | null };
 
       return {
-        vehiculos: vehiculosRes.count || 0,
-        conductores: conductoresRes.count || 0,
-        socios: sociosRes.count || 0,
-        remolques: remolquesRes.count || 0,
-        cartas_porte: cartasRes.count || 0,
-        viajes: viajesRes.count || 0,
+        vehiculos: vehiculosCount ?? 0,
+        conductores: conductoresCount ?? 0,
+        socios: sociosCount ?? 0,
+        remolques: remolquesCount ?? 0,
+        cartas_porte: cartasCount ?? 0,
+        viajes: viajesCount ?? 0,
       };
     },
     enabled: !!user?.id,


### PR DESCRIPTION
## Summary
- ensure `tipo_combustible` uses a specific union type in vehicle form
- cast vehicle fuel type when editing
- simplify and cast Supabase count queries in `useDashboardCounts`

## Testing
- `npx tsc -p tsconfig.app.json --noEmit`
- `npm run build`
- `npm run lint` *(fails: 836 errors, 74 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6862e688adb8832b9c16caa05790fe72